### PR TITLE
Replace ReaderT IOSync with a specialized RIO monad

### DIFF
--- a/src/Control/Monad/RIO.js
+++ b/src/Control/Monad/RIO.js
@@ -1,6 +1,6 @@
 // pureImpl  :: forall r a.   a                                -> RIO r a
 exports.pureImpl = function(x) {
-  return function(_) {
+  return function RIO_pure_eff(_) {
     return x;
   };
 };
@@ -8,7 +8,7 @@ exports.pureImpl = function(x) {
 // mapImpl   :: forall r a b. (a -> b)       -> RIO r a        -> RIO r b
 exports.mapImpl = function(f) {
   return function(io_x) {
-    return function(env) {
+    return function RIO_map_eff(env) {
       return f(io_x(env));
     };
   };
@@ -17,7 +17,7 @@ exports.mapImpl = function(f) {
 // applyImpl :: forall r a b. RIO r (a -> b) -> RIO r a        -> RIO r b
 exports.applyImpl = function(io_f) {
   return function(io_x) {
-    return function(env) {
+    return function RIO_apply_eff(env) {
       var f = io_f(env);
       return f(io_x(env));
     };
@@ -27,21 +27,21 @@ exports.applyImpl = function(io_f) {
 // bindImpl  :: forall r a b. RIO r a        -> (a -> RIO r b) -> RIO r b
 exports.bindImpl = function(io_x) {
   return function(k) {
-    return function(env) {
+    return function RIO_bind_eff(env) {
       return k(io_x(env))(env);
     };
   };
 };
 
 // askImpl   :: forall r. RIO r r
-exports.askImpl = function(env) {
+exports.askImpl = function RIO_ask_eff(env) {
   return env;
 };
 
 // runRIO :: forall r a. r -> RIO r a -> IOSync a
 exports.runRIO = function(env) {
   return function(io) {
-    return function() {
+    return function runRIO_eff() {
       return io(env);
     };
   };
@@ -49,7 +49,7 @@ exports.runRIO = function(env) {
 
 // rio :: forall r a. (r -> IOSync a) -> RIO r a
 exports.rio = function(f) {
-  return function(env) {
+  return function RIO_rio_eff(env) {
     return f(env)();
   };
 };
@@ -57,7 +57,7 @@ exports.rio = function(f) {
 // local :: forall r e a. (e -> r) -> RIO r a -> RIO e a
 exports.local = function(f) {
   return function(io) {
-    return function(env) {
+    return function RIO_local_eff(env) {
       return io(f(env));
     };
   };

--- a/src/Control/Monad/RIO.js
+++ b/src/Control/Monad/RIO.js
@@ -1,0 +1,64 @@
+// pureImpl  :: forall r a.   a                                -> RIO r a
+exports.pureImpl = function(x) {
+  return function(_) {
+    return x;
+  };
+};
+
+// mapImpl   :: forall r a b. (a -> b)       -> RIO r a        -> RIO r b
+exports.mapImpl = function(f) {
+  return function(io_x) {
+    return function(env) {
+      return f(io_x(env));
+    };
+  };
+};
+
+// applyImpl :: forall r a b. RIO r (a -> b) -> RIO r a        -> RIO r b
+exports.applyImpl = function(io_f) {
+  return function(io_x) {
+    return function(env) {
+      var f = io_f(env);
+      return f(io_x(env));
+    };
+  };
+};
+
+// bindImpl  :: forall r a b. RIO r a        -> (a -> RIO r b) -> RIO r b
+exports.bindImpl = function(io_x) {
+  return function(k) {
+    return function(env) {
+      return k(io_x(env))(env);
+    };
+  };
+};
+
+// askImpl   :: forall r. RIO r r
+exports.askImpl = function(env) {
+  return env;
+};
+
+// runRIO :: forall r a. r -> RIO r a -> IOSync a
+exports.runRIO = function(env) {
+  return function(io) {
+    return function() {
+      return io(env);
+    };
+  };
+};
+
+// rio :: forall r a. (r -> IOSync a) -> RIO r a
+exports.rio = function(f) {
+  return function(env) {
+    return f(env)();
+  };
+};
+
+// local :: forall r e a. (e -> r) -> RIO r a -> RIO e a
+exports.local = function(f) {
+  return function(io) {
+    return function(env) {
+      return io(f(env));
+    };
+  };
+};

--- a/src/Control/Monad/RIO.purs
+++ b/src/Control/Monad/RIO.purs
@@ -1,0 +1,54 @@
+module Control.Monad.RIO
+  ( RIO(..)
+  , INF
+  , rio
+  , runRIO
+  , local
+  ) where
+
+import Prelude
+
+import Control.Monad.Eff.Class (class MonadEff)
+import Control.Monad.Eff.Uncurried (EffFn1)
+import Control.Monad.IO.Effect (INFINITY)
+import Control.Monad.IOSync (IOSync)
+import Control.Monad.IOSync.Class (class MonadIOSync)
+import Control.Monad.Reader.Class (class MonadAsk)
+import Unsafe.Coerce (unsafeCoerce)
+
+type INF = (infinity :: INFINITY)
+
+newtype RIO r a = RIO (EffFn1 INF r a)
+
+instance functorRIO :: Functor (RIO r) where
+  map = mapImpl
+
+instance applyRIO :: Apply (RIO r) where
+  apply = applyImpl
+
+instance applicativeRIO :: Applicative (RIO r) where
+  pure = pureImpl
+
+instance bindRIO :: Bind (RIO r) where
+  bind = bindImpl
+
+instance monadRIO :: Monad (RIO r)
+
+instance monadAskRIO :: MonadAsk r (RIO r) where
+  ask = askImpl
+
+instance monadEffRIO :: MonadEff eff (RIO r) where
+  liftEff = unsafeCoerce
+
+instance monadIOSyncRIO :: MonadIOSync (RIO r) where
+  liftIOSync = unsafeCoerce
+
+foreign import pureImpl  :: forall r a.   a                                -> RIO r a
+foreign import mapImpl   :: forall r a b. (a -> b)       -> RIO r a        -> RIO r b
+foreign import applyImpl :: forall r a b. RIO r (a -> b) -> RIO r a        -> RIO r b
+foreign import bindImpl  :: forall r a b. RIO r a        -> (a -> RIO r b) -> RIO r b
+foreign import askImpl   :: forall r. RIO r r
+
+foreign import runRIO :: forall r a. r -> RIO r a -> IOSync a
+foreign import rio :: forall r a. (r -> IOSync a) -> RIO r a
+foreign import local :: forall r e a. (e -> r) -> RIO r a -> RIO e a

--- a/src/Specular/Dom/Builder.purs
+++ b/src/Specular/Dom/Builder.purs
@@ -9,10 +9,13 @@ import Control.Monad.Cleanup (class MonadCleanup, CleanupT, onCleanup, runCleanu
 import Control.Monad.Eff.Class (class MonadEff)
 import Control.Monad.IOSync (IOSync)
 import Control.Monad.IOSync.Class (class MonadIOSync, liftIOSync)
-import Control.Monad.Reader (ReaderT, ask, local, runReaderT)
+import Control.Monad.RIO (RIO(..), rio, runRIO)
+import Control.Monad.RIO as RIO
+import Control.Monad.Reader (ReaderT, ask, runReaderT)
 import Control.Monad.Replace (class MonadReplace, Slot(Slot), newSlot)
-import Control.Monad.Trans.Class (class MonadTrans, lift)
 import Data.Array as A
+import Data.DelayedEffects (DelayedEffects)
+import Data.DelayedEffects as DE
 import Data.IORef (modifyIORef, newIORef, readIORef, writeIORef)
 import Data.Maybe (Maybe(..))
 import Data.Monoid (mempty)
@@ -20,36 +23,47 @@ import Data.StrMap as SM
 import Data.Tuple (Tuple(Tuple))
 import Specular.Dom.Builder.Class (class MonadDetach, class MonadDomBuilder)
 import Specular.Dom.Node.Class (class DOM, appendChild, appendRawHtml, createDocumentFragment, createElement, createTextNode, insertBefore, moveAllBetweenInclusive, parentNode, removeAllBetween, removeAttributes, setAttributes, setText)
-import Specular.FRP (class MonadFRP, class MonadHold, class MonadHost, class MonadHostCreate, class MonadPull, foldDyn, hostEffect, newBehavior, newEvent, pull, subscribeEvent_)
-import Specular.FRP.Base (foldDynMaybe)
+import Specular.FRP (class MonadFRP, class MonadHold, class MonadHost, class MonadHostCreate, class MonadPull, foldDyn, foldDynImpl, foldDynMaybeImpl, hostEffect, newBehavior, newEvent, pull, subscribeEvent_)
+import Specular.FRP.Base (foldDynMaybe, subscribeEvent_Impl)
 import Specular.FRP.WeakDynamic (subscribeWeakDyn_)
 
-newtype BuilderT node m a = BuilderT (ReaderT (BuilderEnv node) m a)
+newtype BuilderT node (m :: Type -> Type) a = BuilderT (RIO (BuilderEnv node) a)
 
 type Builder node = BuilderT node (CleanupT IOSync)
 
-derive newtype instance functorBuilderT :: Functor m => Functor (BuilderT node m)
-derive newtype instance applyBuilderT :: Apply m => Apply (BuilderT node m)
-derive newtype instance applicativeBuilderT :: Applicative m => Applicative (BuilderT node m)
-derive newtype instance bindBuilderT :: Bind m => Bind (BuilderT node m)
-derive newtype instance monadBuilderT :: Monad m => Monad (BuilderT node m)
-derive newtype instance monadEffBuilderT :: MonadEff eff m => MonadEff eff (BuilderT node m)
-derive newtype instance monadIOSyncBuilderT :: MonadIOSync m => MonadIOSync (BuilderT node m)
-derive newtype instance monadCleanupBuilderT :: MonadCleanup m => MonadCleanup (BuilderT node m)
-derive newtype instance monadTransBuilderT :: MonadTrans (BuilderT node)
+lift :: forall node m a. IOSync a -> BuilderT node m a
+lift = liftIOSync
 
-unBuilderT :: forall node m a. BuilderT node m a -> ReaderT (BuilderEnv node) m a
+mkBuilder :: forall node m a. (BuilderEnv node -> IOSync a) -> BuilderT node m a
+mkBuilder = BuilderT <<< rio
+
+derive newtype instance functorBuilderT :: Functor (BuilderT node m)
+derive newtype instance applyBuilderT :: Apply (BuilderT node m)
+derive newtype instance applicativeBuilderT :: Applicative (BuilderT node m)
+derive newtype instance bindBuilderT :: Bind (BuilderT node m)
+derive newtype instance monadBuilderT :: Monad (BuilderT node m)
+derive newtype instance monadEffBuilderT :: MonadEff eff (BuilderT node m)
+derive newtype instance monadIOSyncBuilderT :: MonadIOSync (BuilderT node m)
+instance monadCleanupBuilderT :: MonadCleanup (BuilderT node m) where
+  onCleanup action = mkBuilder $ \env -> DE.push env.cleanup action
+
+unBuilderT :: forall node m a. BuilderT node m a -> RIO (BuilderEnv node) a
 unBuilderT (BuilderT f) = f
 
-runBuilder :: forall node a. BuilderEnv node -> Builder node a -> IOSync (Tuple a (IOSync Unit))
-runBuilder env (BuilderT f) = runCleanupT $ runReaderT f env
+runBuilderT :: forall node m a. node -> BuilderT node m a -> IOSync (Tuple a (IOSync Unit))
+runBuilderT parent (BuilderT f) = do
+  actionsMutable <- DE.empty
+  let env = { parent, cleanup: actionsMutable }
+  result <- runRIO env f
+  actions <- DE.unsafeFreeze actionsMutable
+  pure (Tuple result (DE.sequenceEffects actions))
 
-runBuilderT :: forall node m a. BuilderEnv node -> BuilderT node m a -> m a
-runBuilderT env (BuilderT f) = runReaderT f env
+type BuilderEnv node =
+  { parent :: node
+  , cleanup :: DelayedEffects
+  }
 
-type BuilderEnv node = { parent :: node }
-
-getEnv :: forall node m. Monad m => BuilderT node m (BuilderEnv node)
+getEnv :: forall node m. BuilderT node m (BuilderEnv node)
 getEnv = BuilderT ask
 
 setParent :: forall node. node -> BuilderEnv node -> BuilderEnv node
@@ -71,7 +85,7 @@ instance monadReplaceBuilderT :: DOM node
       replace :: forall a. BuilderT node (CleanupT IOSync) a -> IOSync a
       replace inner = do
         fragment <- createDocumentFragment
-        Tuple result cleanup <- runCleanupT $ runBuilderT { parent: fragment } inner
+        Tuple result cleanup <- runBuilderT fragment inner
         join $ readIORef cleanupRef
 
         m_parent <- parentNode placeholderAfter
@@ -100,7 +114,7 @@ instance monadReplaceBuilderT :: DOM node
       append :: IOSync (Slot (BuilderT node (CleanupT IOSync)))
       append = do
         fragment <- createDocumentFragment
-        Tuple slot cleanup <- runCleanupT $ runBuilderT { parent: fragment } newSlot
+        Tuple slot cleanup <- runBuilderT fragment newSlot
         modifyIORef cleanupRef (_ *> cleanup) -- FIXME: memory leak if the inner slot is destroyed
 
         m_parent <- parentNode placeholderAfter
@@ -117,35 +131,29 @@ instance monadReplaceBuilderT :: DOM node
 
     pure $ Slot { replace, destroy, append }
 
-instance monadHoldBuilderT :: MonadHold m => MonadHold (BuilderT node m) where
-  foldDyn f x0 e = lift $ foldDyn f x0 e
-  foldDynMaybe f x0 e = lift $ foldDynMaybe f x0 e
+instance monadHoldBuilderT :: MonadHold (BuilderT node m) where
+  foldDyn = foldDynImpl
+  foldDynMaybe = foldDynMaybeImpl
 
-instance monadPullBuilderT :: MonadPull m => MonadPull (BuilderT node m) where
-  pull = lift <<< pull
+instance monadPullBuilderT :: MonadPull (BuilderT node m) where
+  pull = liftIOSync <<< pull
 
-instance monadHostCreateBuilderT :: (Monad m, MonadHostCreate io m)
-    => MonadHostCreate io (BuilderT node m) where
+instance monadHostCreateBuilderT :: MonadHostCreate IOSync (BuilderT node m) where
   newEvent = lift newEvent
   newBehavior = lift <<< newBehavior
 
-instance monadHostBuilder :: (Monad io, MonadHost io m)
-    => MonadHost io (BuilderT node m) where
-  subscribeEvent_ handler e = lift $ subscribeEvent_ handler e
-  hostEffect = lift <<< hostEffect
+instance monadHostBuilder :: MonadHost IOSync (BuilderT node m) where
+  subscribeEvent_ = subscribeEvent_Impl
+  hostEffect = liftIOSync
 
-instance monadDomBuilderBuilder :: (MonadIOSync m, MonadFRP m, DOM node)
-    => MonadDomBuilder node (BuilderT node m) where
+instance monadDomBuilderBuilder :: DOM node => MonadDomBuilder node (BuilderT node m) where
 
-  text str = do
-    env <- getEnv
-    liftIOSync $ do
-      node <- createTextNode str
-      appendChild node env.parent
+  text str = mkBuilder $ \env -> do
+    node <- createTextNode str
+    appendChild node env.parent
 
   dynText dstr = do
-    env <- getEnv
-    node <- liftIOSync $ do
+    node <- mkBuilder $ \env -> do
       node <- createTextNode ""
       appendChild node env.parent
       pure node
@@ -172,25 +180,24 @@ instance monadDomBuilderBuilder :: (MonadIOSync m, MonadFRP m, DOM node)
         setAttributes node changed
 
     subscribeWeakDyn_ resetAttributes dynAttrs
-    result <- BuilderT $ local (setParent node) (unBuilderT inner)
+    result <- BuilderT $ RIO.local (setParent node) $ unBuilderT inner
     liftIOSync $ appendChild node env.parent
     pure (Tuple node result)
 
-instance monadDetachBuilder :: (MonadIOSync m, MonadCleanup m, DOM node) => MonadDetach (BuilderT node m) where
+instance monadDetachBuilder :: DOM node => MonadDetach (BuilderT node m) where
   detach inner = do
     fragment <- liftIOSync createDocumentFragment
 
     placeholderBefore <- liftIOSync $ createTextNode ""
     liftIOSync $ appendChild placeholderBefore fragment
 
-    result <- lift $ runBuilderT { parent: fragment } inner
+    result <- BuilderT $ RIO.local (setParent fragment) $ unBuilderT inner
 
     placeholderAfter <- liftIOSync $ createTextNode ""
     liftIOSync $ appendChild placeholderAfter fragment
 
     let
-      attach = do
-        env <- getEnv
-        liftIOSync $ moveAllBetweenInclusive placeholderBefore placeholderAfter env.parent
+      attach = mkBuilder $ \env ->
+        moveAllBetweenInclusive placeholderBefore placeholderAfter env.parent
 
     pure { value: result, widget: attach }

--- a/src/Specular/Dom/Builder.purs
+++ b/src/Specular/Dom/Builder.purs
@@ -1,17 +1,17 @@
 module Specular.Dom.Builder (
-    BuilderT
-  , runBuilderT
+    Builder
+  , runBuilder
 ) where
 
 import Prelude
 
-import Control.Monad.Cleanup (class MonadCleanup, CleanupT, onCleanup, runCleanupT)
+import Control.Monad.Cleanup (class MonadCleanup, onCleanup)
 import Control.Monad.Eff.Class (class MonadEff)
 import Control.Monad.IOSync (IOSync)
 import Control.Monad.IOSync.Class (class MonadIOSync, liftIOSync)
-import Control.Monad.RIO (RIO(..), rio, runRIO)
+import Control.Monad.RIO (RIO, rio, runRIO)
 import Control.Monad.RIO as RIO
-import Control.Monad.Reader (ReaderT, ask, runReaderT)
+import Control.Monad.Reader (ask)
 import Control.Monad.Replace (class MonadReplace, Slot(Slot), newSlot)
 import Data.Array as A
 import Data.DelayedEffects (DelayedEffects)
@@ -23,35 +23,30 @@ import Data.StrMap as SM
 import Data.Tuple (Tuple(Tuple))
 import Specular.Dom.Builder.Class (class MonadDetach, class MonadDomBuilder)
 import Specular.Dom.Node.Class (class DOM, appendChild, appendRawHtml, createDocumentFragment, createElement, createTextNode, insertBefore, moveAllBetweenInclusive, parentNode, removeAllBetween, removeAttributes, setAttributes, setText)
-import Specular.FRP (class MonadFRP, class MonadHold, class MonadHost, class MonadHostCreate, class MonadPull, foldDyn, foldDynImpl, foldDynMaybeImpl, hostEffect, newBehavior, newEvent, pull, subscribeEvent_)
-import Specular.FRP.Base (foldDynMaybe, subscribeEvent_Impl)
+import Specular.FRP (class MonadHold, class MonadHost, class MonadHostCreate, class MonadPull, foldDynImpl, foldDynMaybeImpl, newBehavior, newEvent, pull)
+import Specular.FRP.Base (subscribeEvent_Impl)
 import Specular.FRP.WeakDynamic (subscribeWeakDyn_)
 
-newtype BuilderT node (m :: Type -> Type) a = BuilderT (RIO (BuilderEnv node) a)
+newtype Builder node a = Builder (RIO (BuilderEnv node) a)
 
-type Builder node = BuilderT node (CleanupT IOSync)
+mkBuilder :: forall node a. (BuilderEnv node -> IOSync a) -> Builder node a
+mkBuilder = Builder <<< rio
 
-lift :: forall node m a. IOSync a -> BuilderT node m a
-lift = liftIOSync
-
-mkBuilder :: forall node m a. (BuilderEnv node -> IOSync a) -> BuilderT node m a
-mkBuilder = BuilderT <<< rio
-
-derive newtype instance functorBuilderT :: Functor (BuilderT node m)
-derive newtype instance applyBuilderT :: Apply (BuilderT node m)
-derive newtype instance applicativeBuilderT :: Applicative (BuilderT node m)
-derive newtype instance bindBuilderT :: Bind (BuilderT node m)
-derive newtype instance monadBuilderT :: Monad (BuilderT node m)
-derive newtype instance monadEffBuilderT :: MonadEff eff (BuilderT node m)
-derive newtype instance monadIOSyncBuilderT :: MonadIOSync (BuilderT node m)
-instance monadCleanupBuilderT :: MonadCleanup (BuilderT node m) where
+derive newtype instance functorBuilder :: Functor (Builder node)
+derive newtype instance applyBuilder :: Apply (Builder node)
+derive newtype instance applicativeBuilder :: Applicative (Builder node)
+derive newtype instance bindBuilder :: Bind (Builder node)
+derive newtype instance monadBuilder :: Monad (Builder node)
+derive newtype instance monadEffBuilder :: MonadEff eff (Builder node)
+derive newtype instance monadIOSyncBuilder :: MonadIOSync (Builder node)
+instance monadCleanupBuilder :: MonadCleanup (Builder node) where
   onCleanup action = mkBuilder $ \env -> DE.push env.cleanup action
 
-unBuilderT :: forall node m a. BuilderT node m a -> RIO (BuilderEnv node) a
-unBuilderT (BuilderT f) = f
+unBuilder :: forall node a. Builder node a -> RIO (BuilderEnv node) a
+unBuilder (Builder f) = f
 
-runBuilderT :: forall node m a. node -> BuilderT node m a -> IOSync (Tuple a (IOSync Unit))
-runBuilderT parent (BuilderT f) = do
+runBuilder :: forall node a. node -> Builder node a -> IOSync (Tuple a (IOSync Unit))
+runBuilder parent (Builder f) = do
   actionsMutable <- DE.empty
   let env = { parent, cleanup: actionsMutable }
   result <- runRIO env f
@@ -63,14 +58,13 @@ type BuilderEnv node =
   , cleanup :: DelayedEffects
   }
 
-getEnv :: forall node m. BuilderT node m (BuilderEnv node)
-getEnv = BuilderT ask
+getEnv :: forall node. Builder node (BuilderEnv node)
+getEnv = Builder ask
 
 setParent :: forall node. node -> BuilderEnv node -> BuilderEnv node
 setParent parent env = env { parent = parent }
 
-instance monadReplaceBuilderT :: DOM node
-    => MonadReplace (BuilderT node (CleanupT IOSync)) where
+instance monadReplaceBuilder :: DOM node => MonadReplace (Builder node) where
 
   newSlot = do
     env <- getEnv
@@ -82,10 +76,10 @@ instance monadReplaceBuilderT :: DOM node
     cleanupRef <- liftIOSync $ newIORef (mempty :: IOSync Unit)
 
     let
-      replace :: forall a. BuilderT node (CleanupT IOSync) a -> IOSync a
+      replace :: forall a. Builder node a -> IOSync a
       replace inner = do
         fragment <- createDocumentFragment
-        Tuple result cleanup <- runBuilderT fragment inner
+        Tuple result cleanup <- runBuilder fragment inner
         join $ readIORef cleanupRef
 
         m_parent <- parentNode placeholderAfter
@@ -111,10 +105,10 @@ instance monadReplaceBuilderT :: DOM node
       destroy = do
         join $ readIORef cleanupRef
 
-      append :: IOSync (Slot (BuilderT node (CleanupT IOSync)))
+      append :: IOSync (Slot (Builder node))
       append = do
         fragment <- createDocumentFragment
-        Tuple slot cleanup <- runBuilderT fragment newSlot
+        Tuple slot cleanup <- runBuilder fragment newSlot
         modifyIORef cleanupRef (_ *> cleanup) -- FIXME: memory leak if the inner slot is destroyed
 
         m_parent <- parentNode placeholderAfter
@@ -131,22 +125,22 @@ instance monadReplaceBuilderT :: DOM node
 
     pure $ Slot { replace, destroy, append }
 
-instance monadHoldBuilderT :: MonadHold (BuilderT node m) where
+instance monadHoldBuilder :: MonadHold (Builder node) where
   foldDyn = foldDynImpl
   foldDynMaybe = foldDynMaybeImpl
 
-instance monadPullBuilderT :: MonadPull (BuilderT node m) where
+instance monadPullBuilder :: MonadPull (Builder node) where
   pull = liftIOSync <<< pull
 
-instance monadHostCreateBuilderT :: MonadHostCreate IOSync (BuilderT node m) where
-  newEvent = lift newEvent
-  newBehavior = lift <<< newBehavior
+instance monadHostCreateBuilder :: MonadHostCreate IOSync (Builder node) where
+  newEvent = liftIOSync newEvent
+  newBehavior = liftIOSync <<< newBehavior
 
-instance monadHostBuilder :: MonadHost IOSync (BuilderT node m) where
+instance monadHostBuilder :: MonadHost IOSync (Builder node) where
   subscribeEvent_ = subscribeEvent_Impl
   hostEffect = liftIOSync
 
-instance monadDomBuilderBuilder :: DOM node => MonadDomBuilder node (BuilderT node m) where
+instance monadDomBuilderBuilder :: DOM node => MonadDomBuilder node (Builder node) where
 
   text str = mkBuilder $ \env -> do
     node <- createTextNode str
@@ -180,18 +174,18 @@ instance monadDomBuilderBuilder :: DOM node => MonadDomBuilder node (BuilderT no
         setAttributes node changed
 
     subscribeWeakDyn_ resetAttributes dynAttrs
-    result <- BuilderT $ RIO.local (setParent node) $ unBuilderT inner
+    result <- Builder $ RIO.local (setParent node) $ unBuilder inner
     liftIOSync $ appendChild node env.parent
     pure (Tuple node result)
 
-instance monadDetachBuilder :: DOM node => MonadDetach (BuilderT node m) where
+instance monadDetachBuilder :: DOM node => MonadDetach (Builder node) where
   detach inner = do
     fragment <- liftIOSync createDocumentFragment
 
     placeholderBefore <- liftIOSync $ createTextNode ""
     liftIOSync $ appendChild placeholderBefore fragment
 
-    result <- BuilderT $ RIO.local (setParent fragment) $ unBuilderT inner
+    result <- Builder $ RIO.local (setParent fragment) $ unBuilder inner
 
     placeholderAfter <- liftIOSync $ createTextNode ""
     liftIOSync $ appendChild placeholderAfter fragment

--- a/src/Specular/Dom/Widget.purs
+++ b/src/Specular/Dom/Widget.purs
@@ -23,7 +23,7 @@ type Widget = BuilderT Node (CleanupT IOSync)
 
 -- | Runs a widget in the specified parent element. Returns the result and cleanup action.
 runWidgetInNode :: forall a. Node -> Widget a -> IOSync (Tuple a (IOSync Unit))
-runWidgetInNode parent widget = runCleanupT $ runBuilderT {parent} widget
+runWidgetInNode parent widget = runBuilderT parent widget
 
 -- | Runs a widget in the specified parent element and discards cleanup action.
 runMainWidgetInNode :: forall a. Node -> Widget a -> IOSync a

--- a/src/Specular/Dom/Widget.purs
+++ b/src/Specular/Dom/Widget.purs
@@ -9,21 +9,20 @@ module Specular.Dom.Widget (
 
 import Prelude
 
-import Control.Monad.Cleanup (CleanupT, runCleanupT)
 import Control.Monad.IOSync (IOSync)
 import Control.Monad.IOSync.Class (class MonadIOSync)
 import Control.Monad.Replace (class MonadReplace)
 import Data.Tuple (Tuple, fst)
 import Specular.Dom.Browser (Node)
-import Specular.Dom.Builder (BuilderT, runBuilderT)
+import Specular.Dom.Builder (Builder, runBuilder)
 import Specular.Dom.Builder.Class (class MonadDetach, class MonadDomBuilder)
 import Specular.FRP (class MonadHold, class MonadHost)
 
-type Widget = BuilderT Node (CleanupT IOSync)
+type Widget = Builder Node
 
 -- | Runs a widget in the specified parent element. Returns the result and cleanup action.
 runWidgetInNode :: forall a. Node -> Widget a -> IOSync (Tuple a (IOSync Unit))
-runWidgetInNode parent widget = runBuilderT parent widget
+runWidgetInNode parent widget = runBuilder parent widget
 
 -- | Runs a widget in the specified parent element and discards cleanup action.
 runMainWidgetInNode :: forall a. Node -> Widget a -> IOSync a

--- a/src/Specular/FRP/Base.js
+++ b/src/Specular/FRP/Base.js
@@ -1,13 +1,15 @@
-// Frame a ~ DelayedEffects -> Time -> IOSync Unit
 // sequenceFrame_ :: Array (Frame Unit) -> Frame Unit
 exports.sequenceFrame_ = function(xs) {
-  return function(r1) {
-    return function(r2) {
-      return function sequenceFrame_eff() {
-        for(var i = 0; i < xs.length; i++) {
-          xs[i](r1)(r2)();
-        }
-      };
-    };
+  return function sequenceFrame_eff(env) {
+    for(var i = 0; i < xs.length; i++) {
+      xs[i](env);
+    }
+  };
+};
+
+// unsafeMkPull :: forall a. (Time -> IOSync a) -> Pull a
+exports.unsafeMkPull = function(f) {
+  return function(env) {
+    return f(env)();
   };
 };

--- a/test/node/Main.purs
+++ b/test/node/Main.purs
@@ -10,11 +10,13 @@ import EventSpec as EventSpec
 import DynamicSpec as DynamicSpec
 import FixSpec as FixSpec
 import WeakDynamicSpec as WeakDynamicSpec
+import RIOSpec as RIOSpec
 
 main :: Eff (RunnerEffects ()) Unit
 main = run [consoleReporter] do
   FixSpec.spec
-  DynamicSpec.spec
   EventSpec.spec
+  DynamicSpec.spec
   UniqueMapMutableSpec.spec
   WeakDynamicSpec.spec
+  RIOSpec.spec

--- a/test/node/RIOSpec.purs
+++ b/test/node/RIOSpec.purs
@@ -1,0 +1,66 @@
+module RIOSpec where
+
+import Control.Monad.Aff (Aff)
+import Control.Monad.IOSync.Class (liftIOSync)
+import Control.Monad.RIO (RIO, local)
+import Control.Monad.RIO as RIO
+import Control.Monad.Reader.Class (ask)
+import Prelude hiding (append)
+import Test.Spec (Spec, describe, it)
+import Test.Spec.Assertions (shouldEqual)
+import Test.Spec.Runner (RunnerEffects)
+import Test.Utils (assertValues, ioSync, newSpyIO, trigger)
+
+spec :: forall eff. Spec (RunnerEffects eff) Unit
+spec = describe "RIO" $ do
+
+  it "pure" $ do
+    pure 2 `shouldReturn` 2
+
+  it "ask" $ do
+    ask `shouldReturn` testEnv
+
+  it "map" $ do
+    map (add 1) (pure 2) `shouldReturn` 3
+
+  it "liftIOSync" $ do
+    spy <- newSpyIO
+    liftIOSync (trigger spy "effect" "value") `shouldReturn` "value"
+    assertValues spy ["effect"]
+
+  describe "apply" $ do
+    it "pure" $ do
+      (pure (add 1) <*> pure 2) `shouldReturn` 3
+
+    it "effects" $ do
+      spy <- newSpyIO
+      (liftIOSync (trigger spy "f" (add 1)) <*> liftIOSync (trigger spy "x" 2))
+        `shouldReturn` 3
+      assertValues spy ["f", "x"]
+
+  describe "bind" $ do
+    it "pure" $ do
+      (pure 1 >>= \x -> pure (x + 2)) `shouldReturn` 3
+
+    it "effects" $ do
+      spy <- newSpyIO
+      (do x <- liftIOSync (trigger spy "first" "x")
+          liftIOSync (trigger spy "second" (x <> "y")))
+        `shouldReturn` "xy"
+      assertValues spy ["first", "second"]
+
+  it "local" $ do
+    local (add 1) ask `shouldReturn` (testEnv + 1)
+
+type TestEnv = Int
+
+testEnv :: TestEnv
+testEnv = 1
+
+shouldReturn :: forall r t. Show t => Eq t => RIO TestEnv t -> t -> Aff r Unit
+shouldReturn action expected = do
+  actual <- runRIO action
+  actual `shouldEqual` expected
+
+runRIO :: forall r a. RIO TestEnv a -> Aff r a
+runRIO = ioSync <<< RIO.runRIO testEnv


### PR DESCRIPTION
Benchmark shows ~2x performance improvement on static DOM building and certain
Dynamic operations.

Before:

```
+----------------+----------+-------+-------+
| Name           | Op/s     | % max | +-(%) |
+----------------+----------+-------+-------+
| js 10          | 17028.99 | 100   | 4.72  |
| js_c 10        | 15478.49 | 90.89 | 2.86  |
| js_m 10        | 14854.76 | 87.23 | 2.86  |
| static mono 10 | 1418.81  | 8.33  | 6.13  |
| static 10      | 1543.49  | 9.06  | 0.84  |
+----------------+----------+-------+-------+

+----------------+-----------+-------+-------+
| Name           | Op/s      | % max | +-(%) |
+----------------+-----------+-------+-------+
| dyn            | 114756.21 | 100   | 1.97  |
| dyn fmap       | 110134.50 | 95.97 | 1.11  |
| dyn ap pure    | 85197.72  | 74.24 | 1.48  |
| dyn ap self    | 70336.26  | 61.29 | 1.68  |
| dyn bind self  | 46935.49  | 40.90 | 2.36  |
| dyn bind inner | 69144.78  | 60.25 | 0.63  |
| dyn bind outer | 52570.09  | 45.81 | 2.02  |
+----------------+-----------+-------+-------+
```

After:

```
+----------------+----------+-------+-------+
| Name           | Op/s     | % max | +-(%) |
+----------------+----------+-------+-------+
| js 10          | 16476.56 | 100   | 5.22  |
| js_c 10        | 15639.30 | 94.92 | 2.86  |
| js_m 10        | 14925.05 | 90.58 | 3.04  |
| static mono 10 | 2909.45  | 17.66 | 1.26  |
| static 10      | 2926.84  | 17.76 | 2.39  |
+----------------+----------+-------+-------+

+----------------+-----------+-------+-------+
| Name           | Op/s      | % max | +-(%) |
+----------------+-----------+-------+-------+
| dyn            | 210022.95 | 99.08 | 2.15  |
| dyn fmap       | 211983.22 | 100   | 1.10  |
| dyn ap pure    | 179037.69 | 84.46 | 0.81  |
| dyn ap self    | 158005.20 | 74.54 | 0.85  |
| dyn bind self  | 98222.79  | 46.34 | 1.35  |
| dyn bind inner | 161694.28 | 76.28 | 1.11  |
| dyn bind outer | 118295.77 | 55.80 | 1.83  |
+----------------+-----------+-------+-------+
```