### PR TITLE
Remove `io` parameter of MonadHost class

### DIFF
--- a/src/Specular/Dom/Builder.purs
+++ b/src/Specular/Dom/Builder.purs
@@ -133,13 +133,12 @@ instance monadHoldBuilder :: MonadHold (Builder node) where
 instance monadPullBuilder :: MonadPull (Builder node) where
   pull = liftIOSync <<< pull
 
-instance monadHostCreateBuilder :: MonadHostCreate IOSync (Builder node) where
+instance monadHostCreateBuilder :: MonadHostCreate (Builder node) where
   newEvent = liftIOSync newEvent
   newBehavior = liftIOSync <<< newBehavior
 
-instance monadHostBuilder :: MonadHost IOSync (Builder node) where
+instance monadHostBuilder :: MonadHost (Builder node) where
   subscribeEvent_ = subscribeEvent_Impl
-  hostEffect = liftIOSync
 
 instance monadDomBuilderBuilder :: DOM node => MonadDomBuilder node (Builder node) where
 

--- a/src/Specular/Dom/Builder/Class.purs
+++ b/src/Specular/Dom/Builder/Class.purs
@@ -76,7 +76,7 @@ dynRawHtml ::
      forall node m
    . MonadDomBuilder node m
   => MonadReplace m
-  => MonadHost IOSync m
+  => MonadHost m
   => WeakDynamic String
   -> m Unit
 dynRawHtml dynHtml = weakDynamic_ (rawHtml <$> dynHtml)
@@ -85,7 +85,7 @@ dynRawHtml dynHtml = weakDynamic_ (rawHtml <$> dynHtml)
 domEventWithSample ::
      forall event node m a
    . EventDOM event node
-  => MonadHost IOSync m
+  => MonadHost m
   => (event -> IOSync a)
   -> EventType
   -> node
@@ -100,7 +100,7 @@ domEventWithSample sample eventType node = do
 domEvent ::
      forall event node m
    . EventDOM event node
-  => MonadHost IOSync m
+  => MonadHost m
   => EventType
   -> node
   -> m (Event Unit)

--- a/src/Specular/Dom/Widget.purs
+++ b/src/Specular/Dom/Widget.purs
@@ -10,7 +10,6 @@ module Specular.Dom.Widget (
 import Prelude
 
 import Control.Monad.IOSync (IOSync)
-import Control.Monad.IOSync.Class (class MonadIOSync)
 import Control.Monad.Replace (class MonadReplace)
 import Data.Tuple (Tuple, fst)
 import Specular.Dom.Browser (Node)
@@ -37,5 +36,5 @@ runMainWidgetInBody widget = do
 foreign import documentBody :: IOSync Node
 
 -- A handy alias for all the typeclasses you'll need
-class (MonadDomBuilder Node m, MonadHost IOSync m, MonadReplace m, MonadHold m, MonadIOSync m, MonadDetach m) <= MonadWidget m
-instance monadWidget :: (MonadDomBuilder Node m, MonadHost IOSync m, MonadReplace m, MonadHold m, MonadIOSync m, MonadDetach m) => MonadWidget m
+class (MonadDomBuilder Node m, MonadHost m, MonadReplace m, MonadHold m, MonadDetach m) <= MonadWidget m
+instance monadWidget :: (MonadDomBuilder Node m, MonadHost m, MonadReplace m, MonadHold m, MonadDetach m) => MonadWidget m

--- a/src/Specular/FRP/Async.purs
+++ b/src/Specular/FRP/Async.purs
@@ -18,7 +18,6 @@ import Control.Monad.Cleanup (class MonadCleanup, onCleanup)
 import Control.Monad.Eff.Class (liftEff)
 import Control.Monad.Eff.Exception (error)
 import Control.Monad.IO (IO, runIO)
-import Control.Monad.IOSync (IOSync)
 import Control.Monad.IOSync.Class (class MonadIOSync, liftIOSync)
 import Control.Monad.Replace (class MonadReplace)
 import Data.Generic.Rep (class Generic)
@@ -114,7 +113,7 @@ asyncRequest dquery = asyncRequestMaybe (map Just dquery)
 -- FIXME: Does not cancel running actions on cleanup
 performEvent
   :: forall m a
-   . MonadHost IOSync m
+   . MonadHost m
   => Event (IO a)
   -> m (Event a)
 performEvent event = do

--- a/src/Specular/FRP/Base.purs
+++ b/src/Specular/FRP/Base.purs
@@ -70,7 +70,6 @@ import Data.Maybe (Maybe(..), isJust)
 import Data.Traversable (sequence, traverse)
 import Data.UniqueMap.Mutable as UMM
 import Partial.Unsafe (unsafeCrashWith)
-import Unsafe.Coerce (unsafeCoerce)
 
 -------------------------------------------------
 
@@ -344,28 +343,29 @@ mergeEvents whenLeft whenRight whenBoth (Event left) (Event right) =
 mergePulses :: Event Unit -> Event Unit -> Event Unit
 mergePulses = mergeEvents (\_ -> pure unit) (\_ -> pure unit) (\_ _ -> pure unit)
 
-class Monad m <= MonadHostCreate io m | m -> io where
+class Monad m <= MonadHostCreate m where
   -- | Create an Event that can be triggered externally.
   -- | Each `fire` will run a frame where the event occurs.
-  newEvent :: forall a. m { event :: Event a, fire :: a -> io Unit }
+  newEvent :: forall a. m { event :: Event a, fire :: a -> IOSync Unit }
 
   -- | Create a new Behavior whose value can be modified outside a frame.
-  newBehavior :: forall a. a -> m { behavior :: Behavior a, set :: a -> io Unit }
+  newBehavior :: forall a. a -> m { behavior :: Behavior a, set :: a -> IOSync Unit }
 
-instance monadHostCreateReaderT :: MonadHostCreate io m => MonadHostCreate io (ReaderT r m) where
+instance monadHostCreateReaderT :: MonadHostCreate m => MonadHostCreate (ReaderT r m) where
   newEvent = lift newEvent
   newBehavior = lift <<< newBehavior
 
-class (Monad io, Monad m, MonadPull m, MonadCleanup m, MonadHostCreate io m) <= MonadHost io m | m -> io where
-  subscribeEvent_ :: forall a. (a -> io Unit) -> Event a -> m Unit
+class (Monad m, MonadIOSync m, MonadPull m, MonadCleanup m, MonadHostCreate m) <= MonadHost m where
+  subscribeEvent_ :: forall a. (a -> IOSync Unit) -> Event a -> m Unit
 
-  hostEffect :: forall a. io a -> m a
+-- | DEPRECATED: Replace this with `liftIOSync`.
+hostEffect :: forall m a. MonadIOSync m => IOSync a -> m a
+hostEffect = liftIOSync
 
-instance monadHostReaderT :: (Monad io, MonadHost io m) => MonadHost io (ReaderT r m) where
+instance monadHostReaderT :: MonadHost m => MonadHost (ReaderT r m) where
   subscribeEvent_ f event = lift (subscribeEvent_ f event)
-  hostEffect = lift <<< hostEffect
 
-instance monadHostCreateIOSync :: MonadHostCreate IOSync IOSync where
+instance monadHostCreateIOSync :: MonadHostCreate IOSync where
   newEvent = do
     occurenceRef <- newIORef Nothing
     listenerMap <- UMM.new
@@ -390,13 +390,12 @@ instance monadHostCreateIOSync :: MonadHostCreate IOSync IOSync where
 
 foreign import sequenceFrame_ :: Array (Frame Unit) -> Frame Unit
 
-instance monadHostCreateCleanupT :: (Monad m, MonadHostCreate io m) => MonadHostCreate io (CleanupT m) where
+instance monadHostCreateCleanupT :: (Monad m, MonadHostCreate m) => MonadHostCreate (CleanupT m) where
   newEvent = lift newEvent
   newBehavior = lift <<< newBehavior
 
-instance monadHostCleanupT :: MonadHost IOSync (CleanupT IOSync) where
+instance monadHostCleanupT :: MonadHost (CleanupT IOSync) where
   subscribeEvent_ = subscribeEvent_Impl
-  hostEffect = liftIOSync
 
 subscribeEvent_Impl :: forall m a. MonadCleanup m => MonadIOSync m => (a -> IOSync Unit) -> Event a -> m Unit
 subscribeEvent_Impl handler (Event {occurence,subscribe}) = do
@@ -633,24 +632,22 @@ instance bindDynamic :: Bind Dynamic where
 
 instance monadDynamic :: Monad Dynamic
 
-subscribeDyn_ ::
-     forall io m a
-   . MonadHost io m
-  => Monad m -- FIXME: why is this needed?
-  => (a -> io Unit)
+subscribeDyn_
+  :: forall m a
+   . MonadHost m
+  => (a -> IOSync Unit)
   -> Dynamic a
   -> m Unit
 subscribeDyn_ handler (Dynamic {value, change}) = do
   currentValue <- pull $ readBehavior value
-  hostEffect $ handler currentValue
+  liftIOSync $ handler currentValue
   subscribeEvent_ handler (mapEventB (\_ -> value) change)
 
 subscribeDyn ::
-     forall io m a b
-   . MonadHost io m
+     forall m a b
+   . MonadHost m
   => MonadHold m
-  => Monad io -- FIXME: why is this needed?
-  => (a -> io b)
+  => (a -> IOSync b)
   -> Dynamic a
   -> m (Dynamic b)
 subscribeDyn handler dyn = do
@@ -677,8 +674,8 @@ latestJust dyn = do
   currentValue <- pull $ readBehavior $ current dyn
   foldDynMaybe (\new _ -> map Just new) currentValue (changed dyn)
 
-class (MonadHold m, MonadHost IOSync m, MonadIOSync m) <= MonadFRP m
-instance monadFRP :: (MonadHold m, MonadHost IOSync m, MonadIOSync m) => MonadFRP m
+class (MonadHold m, MonadHost m) <= MonadFRP m
+instance monadFRP :: (MonadHold m, MonadHost m) => MonadFRP m
 
 -- | Flipped `map`.
 -- |

--- a/src/Specular/FRP/Fix.purs
+++ b/src/Specular/FRP/Fix.purs
@@ -20,8 +20,8 @@ import Type.Prelude (class IsSymbol, class RowLacks)
 import Type.Row (class RowToList, Cons, Nil, RLProxy(..))
 
 fixEvent ::
-     forall m io a b
-   . MonadHost io m
+     forall m a b
+   . MonadHost m
   => (Event a -> m (Tuple (Event a) b))
   -> m b
 fixEvent f = do
@@ -31,8 +31,8 @@ fixEvent f = do
   pure result
 
 fixDyn ::
-     forall m io a b
-   . MonadHost io m
+     forall m a b
+   . MonadHost m
   => MonadHold m
   => (WeakDynamic a -> m (Tuple (Dynamic a) b))
   -> m b
@@ -43,11 +43,11 @@ fixDyn f = do
   subscribeDyn_ fire dyn
   pure result
 
-fixFRP_ :: forall input output m io. FixFRP input output => MonadHost io m => MonadHold m => (input -> m output) -> m Unit
+fixFRP_ :: forall input output m. FixFRP input output => MonadHost m => MonadHold m => (input -> m output) -> m Unit
 fixFRP_ f = fixFRP (\input -> (\x -> Tuple x unit) <$> f input)
 
 class FixFRP input output | output -> input, input -> output where
-  fixFRP :: forall m io b. MonadHost io m => MonadHold m => (input -> m (Tuple output b)) -> m b
+  fixFRP :: forall m b. MonadHost m => MonadHold m => (input -> m (Tuple output b)) -> m b
 
 instance fixFRPEvent :: FixFRP (Event a) (Event a) where
   fixFRP = fixEvent
@@ -59,8 +59,8 @@ instance fixFRPRecord :: (FixFRPRecord ro_list ri ro, RowToList ro ro_list) => F
   fixFRP = fixRecord (RLProxy :: RLProxy ro_list)
 
 class FixFRPRecord ro_list ri ro | ro_list -> ri ro where
-  fixRecord :: forall m io b
-     . MonadHost io m
+  fixRecord :: forall m b
+     . MonadHost m
     => MonadHold m
     => RLProxy ro_list
     -> (Record ri -> m (Tuple (Record ro) b))

--- a/src/Specular/FRP/Replaceable.purs
+++ b/src/Specular/FRP/Replaceable.purs
@@ -2,27 +2,26 @@ module Specular.FRP.Replaceable where
 
 import Prelude
 
-import Control.Monad.IOSync (IOSync)
 import Control.Monad.Replace (class MonadReplace, Slot(Slot), newSlot)
 import Specular.FRP.Base (class MonadHold, class MonadHost, Dynamic, subscribeDyn, subscribeDyn_)
 import Specular.FRP.WeakDynamic (WeakDynamic, subscribeWeakDyn, subscribeWeakDyn_)
 
-dynamic_ :: forall m. MonadReplace m => MonadHost IOSync m => Dynamic (m Unit) -> m Unit
+dynamic_ :: forall m. MonadReplace m => MonadHost m => Dynamic (m Unit) -> m Unit
 dynamic_ dyn = do
   Slot {replace} <- newSlot
   subscribeDyn_ (\x -> replace x) dyn
 
-dynamic :: forall m a. MonadReplace m => MonadHold m => MonadHost IOSync m => Dynamic (m a) -> m (Dynamic a)
+dynamic :: forall m a. MonadReplace m => MonadHold m => MonadHost m => Dynamic (m a) -> m (Dynamic a)
 dynamic dyn = do
   Slot {replace} <- newSlot
   subscribeDyn (\x -> replace x) dyn
 
-weakDynamic_ :: forall m. MonadReplace m => MonadHost IOSync m => WeakDynamic (m Unit) -> m Unit
+weakDynamic_ :: forall m. MonadReplace m => MonadHost m => WeakDynamic (m Unit) -> m Unit
 weakDynamic_ dyn = do
   Slot {replace} <- newSlot
   subscribeWeakDyn_ (\x -> replace x) dyn
 
-weakDynamic :: forall m a. MonadReplace m => MonadHold m => MonadHost IOSync m => WeakDynamic (m a) -> m (WeakDynamic a)
+weakDynamic :: forall m a. MonadReplace m => MonadHold m => MonadHost m => WeakDynamic (m a) -> m (WeakDynamic a)
 weakDynamic dyn = do
   Slot {replace} <- newSlot
   subscribeWeakDyn (\x -> replace x) dyn

--- a/src/Specular/FRP/WeakDynamic.purs
+++ b/src/Specular/FRP/WeakDynamic.purs
@@ -12,6 +12,7 @@ module Specular.FRP.WeakDynamic (
 
 import Prelude
 
+import Control.Monad.IOSync (IOSync)
 import Data.Foldable (traverse_)
 import Data.Functor.Compose (Compose(..))
 import Data.Maybe (Maybe(..), fromMaybe)
@@ -61,10 +62,9 @@ switchWeakDyn (WeakDynamic (Compose mdyn)) = switch $ map (fromMaybe never) mdyn
 -- | Invoke the handler immediately if the WeakDynamic has a value currently,
 -- | and invoke it every time it changes, until cleanup.
 subscribeWeakDyn_ ::
-     forall io m a
-   . MonadHost io m
-  => Applicative io
-  => (a -> io Unit)
+     forall m a
+   . MonadHost m
+  => (a -> IOSync Unit)
   -> WeakDynamic a
   -> m Unit
 subscribeWeakDyn_ handler (WeakDynamic (Compose mdyn)) =
@@ -73,12 +73,10 @@ subscribeWeakDyn_ handler (WeakDynamic (Compose mdyn)) =
 -- | Invoke the handler immediately if the WeakDynamic has a value currently,
 -- | and invoke it every time it changes, until cleanup.
 subscribeWeakDyn ::
-     forall io m a b
-   . MonadHost io m
+     forall m a b
+   . MonadHost m
   => MonadHold m
-  => Monad io
-  => Applicative io
-  => (a -> io b)
+  => (a -> IOSync b)
   -> WeakDynamic a
   -> m (WeakDynamic b)
 subscribeWeakDyn handler wdyn = do


### PR DESCRIPTION
Reason: We never really needed this flexibility.