### PR TITLE
Make a specialized `elAttr` function

### DIFF
--- a/src/Specular/Dom/Builder.purs
+++ b/src/Specular/Dom/Builder.purs
@@ -178,6 +178,14 @@ instance monadDomBuilderBuilder :: DOM node => MonadDomBuilder node (Builder nod
     liftIOSync $ appendChild node env.parent
     pure (Tuple node result)
 
+  elAttr tagName attrs inner = do
+    env <- getEnv
+    node <- liftIOSync $ createElementNS Nothing tagName
+    liftIOSync $ setAttributes node attrs
+    result <- Builder $ RIO.local (setParent node) $ unBuilder inner
+    liftIOSync $ appendChild node env.parent
+    pure result
+
 instance monadDetachBuilder :: DOM node => MonadDetach (Builder node) where
   detach inner = do
     fragment <- liftIOSync createDocumentFragment

--- a/src/Specular/Dom/Builder/Class.purs
+++ b/src/Specular/Dom/Builder/Class.purs
@@ -19,6 +19,8 @@ class Monad m <= MonadDomBuilder node m | m -> node where
   elDynAttrNS' :: forall a. Maybe Namespace -> TagName -> WeakDynamic Attrs -> m a -> m (Tuple node a)
   rawHtml :: String -> m Unit
 
+  elAttr :: forall a. TagName -> Attrs -> m a -> m a
+
 elDynAttr'
   :: forall m node a. MonadDomBuilder node m
   => String -> WeakDynamic Attrs -> m a -> m (Tuple node a)
@@ -44,16 +46,6 @@ elAttr' ::
 elAttr' tagName attrs inner = elDynAttr' tagName (pure attrs) inner
 
 
-elAttr ::
-     forall node m a
-   . MonadDomBuilder node m
-  => String
-  -> Attrs
-  -> m a
-  -> m a
-elAttr tagName attrs inner = snd <$> elAttr' tagName attrs inner
-
-
 el' ::
      forall node m a
    . MonadDomBuilder node m
@@ -69,7 +61,7 @@ el ::
   => String
   -> m a
   -> m a
-el tagName inner = snd <$> el' tagName inner
+el tagName inner = elAttr tagName mempty inner
 
 
 dynRawHtml ::
@@ -111,6 +103,8 @@ instance monadDomBuilderReaderT :: MonadDomBuilder node m => MonadDomBuilder nod
   dynText = lift <<< dynText
   elDynAttrNS' ns tag attrs body = ReaderT $ \env -> elDynAttrNS' ns tag attrs $ runReaderT body env
   rawHtml = lift <<< rawHtml
+  elAttr tag attrs body =
+    ReaderT $ \env -> elAttr tag attrs $ runReaderT body env
 
 class MonadDetach m where
   -- | Initialize a widget without displaying it immediately.


### PR DESCRIPTION
Since this (and `el`) is such a common case, it should speed up DOM
building.

~2x speedup on static DOM building benchmark (which uses only `elAttr`).

Before:

```
+----------------+----------+-------+-------+
| Name           | Op/s     | % max | +-(%) |
+----------------+----------+-------+-------+
| js 10          | 16359.82 | 100   | 4.50  |
| js_c 10        | 13945.26 | 85.24 | 3.05  |
| js_m 10        | 13272.51 | 81.13 | 3.42  |
| static mono 10 | 2718.16  | 16.61 | 1.39  |
| static 10      | 2715.30  | 16.60 | 1.61  |
+----------------+----------+-------+-------+
```

After:

```
+----------------+----------+-------+-------+
| Name           | Op/s     | % max | +-(%) |
+----------------+----------+-------+-------+
| js 10          | 17785.71 | 100   | 4.50  |
| js_c 10        | 14925.13 | 83.92 | 2.62  |
| js_m 10        | 14440.06 | 81.19 | 2.53  |
| static mono 10 | 6103.31  | 34.32 | 1.75  |
| static 10      | 6186.16  | 34.78 | 1.37  |
+----------------+----------+-------+-------+
```