### PR TITLE
Make asyncRequest not require MonadReplace

### DIFF
--- a/test/browser/BrowserMain.purs
+++ b/test/browser/BrowserMain.purs
@@ -2,7 +2,6 @@ module BrowserMain where
 
 import Prelude
 
-import AsyncSpec as AsyncSpec
 import BuilderSpec as BuilderSpec
 import Effect (Effect)
 import Examples.AsyncRequest as AsyncRequest
@@ -21,7 +20,6 @@ main = run [consoleReporter] do
   InputWidgetsSpec.spec
   ListSpec.spec
   RadioGroupSpec.spec
-  AsyncSpec.spec
 
   describe "example apps" $ do
     Counter.spec

--- a/test/node/AsyncSpec.purs
+++ b/test/node/AsyncSpec.purs
@@ -1,11 +1,9 @@
--- NB: this module is in browser tests, not node tests, because `asyncRequest`
--- requires MonadWidget. This should change in the future.
 module AsyncSpec where
 
 import Prelude hiding (append)
 
 import BuilderSpec (newDynamic)
-import Control.Monad.Cleanup (runCleanupT)
+import Control.Monad.Cleanup (execCleanupT, runCleanupT)
 import Data.Maybe (Maybe(..))
 import Data.Tuple (Tuple(..), fst, snd)
 import Effect.Aff (Aff)
@@ -17,7 +15,6 @@ import Specular.FRP.Base (readBehavior, subscribeDyn_)
 import Specular.Internal.Effect (newRef)
 import Test.Spec (Spec, describe, it)
 import Test.Utils (append, clear, shouldHaveValue, shouldReturn, yieldAff)
-import Test.Utils.Dom (runBuilderInDiv)
 
 spec :: Spec Unit
 spec = do
@@ -28,7 +25,7 @@ spec = do
 
       let request =  AVar.take avar
 
-      _ <- runBuilderInDiv $ do
+      _ <- execCleanupT do
         result <- asyncRequestMaybe $ pure $ Just request
         subscribeDyn_ (append log) result
 
@@ -47,7 +44,7 @@ spec = do
 
       Tuple dyn setDyn <- liftEffect $ newDynamic Nothing
 
-      _ <- runBuilderInDiv $ do
+      _ <- execCleanupT do
         result <- asyncRequestMaybe dyn
         subscribeDyn_ (append log) result
 
@@ -69,7 +66,7 @@ spec = do
 
       Tuple dyn setDyn <- liftEffect $ newDynamic Nothing
 
-      _ <- runBuilderInDiv $ do
+      _ <- execCleanupT do
         result <- asyncRequestMaybe dyn
         subscribeDyn_ (append log) result
 
@@ -96,7 +93,7 @@ spec = do
 
       Tuple dyn setDyn <- liftEffect $ newDynamic Nothing
 
-      _ <- runBuilderInDiv $ do
+      _ <- execCleanupT do
         result <- asyncRequestMaybe dyn
         subscribeDyn_ (append log) result
 
@@ -136,7 +133,7 @@ spec = do
       -- The first String is the request description, the second is the result.
       log <- liftEffect $ newRef []
 
-      Tuple _ result <- runBuilderInDiv $ do
+      Tuple result _ <- runCleanupT do
         status <- asyncRequestMaybe $ map snd dyn
         let result = Tuple <$> map fst dyn <*> status
         subscribeDyn_ (append log) $ result

--- a/test/node/Main.purs
+++ b/test/node/Main.purs
@@ -2,6 +2,7 @@ module Test.Main where
 
 import Prelude
 
+import AsyncSpec as AsyncSpec
 import DynamicSpec as DynamicSpec
 import Effect (Effect)
 import EventSpec as EventSpec
@@ -22,3 +23,4 @@ main = run [consoleReporter] do
   WeakDynamicSpec.spec
   RIOSpec.spec
   TraceSpec.spec
+  AsyncSpec.spec


### PR DESCRIPTION
Due to laziness on my part when implementing it, `asyncRequest` required `MonadReplace` constraint.
This patch changes the implementation so that it doesn't rely on `MonadReplace`. The request is still killed on cleanup.