### PR TITLE
Rename Debug.Specular -> Specular.Debug

### DIFF
--- a/src/Specular/Debug.purs
+++ b/src/Specular/Debug.purs
@@ -1,4 +1,4 @@
-module Debug.Specular
+module Specular.Debug
   ( traceEventWith
   , traceEvent
   , traceDynWith


### PR DESCRIPTION
Fixes #30 .