### PR TITLE
Use EffectFnN for some primitives

### DIFF
--- a/src/Specular/Internal/Effect.js
+++ b/src/Specular/Internal/Effect.js
@@ -1,51 +1,42 @@
 // data Ref :: Type -> Type
 
-// newRef :: forall a. a -> Effect (Ref a)
+// _newRef :: forall a. EffectFn1 a (Ref a)
 exports._newRef = function(initial) {
   return {
     value: initial
   };
 };
 
-// readRef :: forall a. Ref a -> Effect a
+// _readRef :: forall a. EffectFn1 (Ref a) a
 exports._readRef = function(ref) {
   return ref.value;
 };
 
-// writeRef :: forall a. Ref a -> a -> Effect Unit
+// _writeRef :: forall a. EffectFn2 (Ref a) a Unit
 exports._writeRef = function(ref, newValue) {
   ref.value = newValue;
 };
 
 // data DelayedEffects :: Type
 
-
 // emptyDelayed :: Effect DelayedEffects
 exports.emptyDelayed = function() {
   return [];
 };
 
-// pushDelayed :: DelayedEffects -> Effect Unit -> Effect Unit
-exports.pushDelayed = function(effs) {
-  return function(eff) {
-    return function() {
-      effs.push(eff);
-    };
-  };
+// _pushDelayed :: EffectFn2 DelayedEffects (Effect Unit) Unit
+exports._pushDelayed = function(effs, eff) {
+  effs.push(eff);
 };
 
-// unsafeFreezeDelayed :: DelayedEffects -> Effect (Array (Effect Unit))
-exports.unsafeFreezeDelayed = function(x) {
-  return function() {
-    return x;
-  };
+// _unsafeFreezeDelayed :: EffectFn1 DelayedEffects (Array (Effect Unit))
+exports._unsafeFreezeDelayed = function(x) {
+  return x;
 };
 
-// sequenceEffects :: Array (Effect Unit) -> Effect Unit
-exports.sequenceEffects = function(effects) {
-  return function sequenceEffects_eff() {
-    for(var i = 0; i < effects.length; i++) {
-      effects[i]();
-    }
-  };
+// _sequenceEffects :: EffectFn1 (Array (Effect Unit)) Unit
+exports._sequenceEffects = function(effects) {
+  for(var i = 0; i < effects.length; i++) {
+    effects[i]();
+  }
 };

--- a/src/Specular/Internal/Effect.js
+++ b/src/Specular/Internal/Effect.js
@@ -1,28 +1,20 @@
 // data Ref :: Type -> Type
 
 // newRef :: forall a. a -> Effect (Ref a)
-exports.newRef = function(initial) {
-  return function() {
-    return {
-      value: initial
-    };
+exports._newRef = function(initial) {
+  return {
+    value: initial
   };
 };
 
 // readRef :: forall a. Ref a -> Effect a
-exports.readRef = function(ref) {
-  return function() {
-    return ref.value;
-  };
+exports._readRef = function(ref) {
+  return ref.value;
 };
 
 // writeRef :: forall a. Ref a -> a -> Effect Unit
-exports.writeRef = function(ref) {
-  return function(newValue) {
-    return function() {
-      ref.value = newValue;
-    };
-  };
+exports._writeRef = function(ref, newValue) {
+  ref.value = newValue;
 };
 
 // data DelayedEffects :: Type

--- a/src/Specular/Internal/Effect.purs
+++ b/src/Specular/Internal/Effect.purs
@@ -2,13 +2,16 @@ module Specular.Internal.Effect
   ( module Effect
 
   , Ref
+
   , newRef
   , readRef
   , writeRef
+  , modifyRef
+
+  -- EffectFn versions
   , _newRef
   , _readRef
   , _writeRef
-  , modifyRef
 
   , DelayedEffects
   , emptyDelayed
@@ -52,8 +55,17 @@ foreign import data DelayedEffects :: Type
 
 foreign import emptyDelayed :: Effect DelayedEffects
 
-foreign import pushDelayed :: DelayedEffects -> Effect Unit -> Effect Unit
+pushDelayed :: DelayedEffects -> Effect Unit -> Effect Unit
+pushDelayed x y = runEffectFn2 _pushDelayed x y
 
-foreign import unsafeFreezeDelayed :: DelayedEffects -> Effect (Array (Effect Unit))
+foreign import _pushDelayed :: EffectFn2 DelayedEffects (Effect Unit) Unit
 
-foreign import sequenceEffects :: Array (Effect Unit) -> Effect Unit
+unsafeFreezeDelayed :: DelayedEffects -> Effect (Array (Effect Unit))
+unsafeFreezeDelayed x = runEffectFn1 _unsafeFreezeDelayed x
+
+foreign import _unsafeFreezeDelayed :: EffectFn1 DelayedEffects (Array (Effect Unit))
+
+sequenceEffects :: Array (Effect Unit) -> Effect Unit
+sequenceEffects x = runEffectFn1 _sequenceEffects x
+
+foreign import _sequenceEffects :: EffectFn1 (Array (Effect Unit)) Unit

--- a/src/Specular/Internal/Effect.purs
+++ b/src/Specular/Internal/Effect.purs
@@ -5,6 +5,9 @@ module Specular.Internal.Effect
   , newRef
   , readRef
   , writeRef
+  , _newRef
+  , _readRef
+  , _writeRef
   , modifyRef
 
   , DelayedEffects
@@ -17,16 +20,26 @@ module Specular.Internal.Effect
 import Prelude
 
 import Effect (Effect)
+import Effect.Uncurried (EffectFn1, EffectFn2, runEffectFn1, runEffectFn2)
 
 -- effects
 
 foreign import data Ref :: Type -> Type
 
-foreign import newRef :: forall a. a -> Effect (Ref a)
+newRef :: forall a. a -> Effect (Ref a)
+newRef x = runEffectFn1 _newRef x
 
-foreign import readRef :: forall a. Ref a -> Effect a
+foreign import _newRef :: forall a. EffectFn1 a (Ref a)
 
-foreign import writeRef :: forall a. Ref a -> a -> Effect Unit
+readRef :: forall a. Ref a -> Effect a
+readRef x = runEffectFn1 _readRef x
+
+foreign import _readRef :: forall a. EffectFn1 (Ref a) a
+
+writeRef :: forall a. Ref a -> a -> Effect Unit
+writeRef x y = runEffectFn2 _writeRef x y
+
+foreign import _writeRef :: forall a. EffectFn2 (Ref a) a Unit
 
 modifyRef :: forall a. Ref a -> (a -> a) -> Effect Unit
 modifyRef ref f = do


### PR DESCRIPTION
This compiles to better JS (no allocation of intermediate closures), ~and
gives us some performance boost~ **update: it's actually slightly slower on modern browsers**.