### PR TITLE
Fix checkbox getting out of sync sync with dynamic

### DIFF
--- a/src/Specular/Dom/Widgets/Input.js
+++ b/src/Specular/Dom/Widgets/Input.js
@@ -20,3 +20,12 @@ exports.getCheckboxChecked = function(node) {
     return node.checked;
   };
 };
+
+// setCheckboxChecked :: Node -> Boolean -> IOSync Unit
+exports.setCheckboxChecked = function(node) {
+  return function(value) {
+    return function() {
+      return node.checked = value;
+    };
+  };
+};

--- a/src/Specular/Dom/Widgets/Input.purs
+++ b/src/Specular/Dom/Widgets/Input.purs
@@ -24,7 +24,6 @@ module Specular.Dom.Widgets.Input (
 
 import Prelude
 
-import Control.Apply (lift2)
 import Effect (Effect)
 import Effect.Class (liftEffect)
 import Data.Tuple (Tuple(..))
@@ -82,10 +81,7 @@ booleanInputView :: forall m. MonadWidget m
   -> WeakDynamic Attrs
   -> m (Event Boolean)
 booleanInputView type_ dchecked dattrs = do
-  let dattrs' = lift2 (\attrs checked -> attrs <>
-                        ("type" := booleanInputTypeToAttributeValue type_) <>
-                        (if checked then "checked" := "checked" else mempty)
-                     ) dattrs dchecked
+  let dattrs' = map (\attrs -> attrs <> ("type" := booleanInputTypeToAttributeValue type_)) dattrs
 
   Tuple node _ <- elDynAttr' "input" dattrs' (pure unit)
   subscribeWeakDyn_ (setCheckboxChecked node) dchecked

--- a/src/Specular/Dom/Widgets/Input.purs
+++ b/src/Specular/Dom/Widgets/Input.purs
@@ -1,5 +1,5 @@
 module Specular.Dom.Widgets.Input (
-    textInputOnChange  
+    textInputOnChange
   , textInputOnInput
   , textareaOnChange
 
@@ -14,10 +14,12 @@ module Specular.Dom.Widgets.Input (
   , checkboxView
   , BooleanInputType(..)
   , booleanInputView
-  
+
   -- TODO: move to Internal
   , getTextInputValue
   , setTextInputValue
+  , getCheckboxChecked
+  , setCheckboxChecked
 ) where
 
 import Prelude

--- a/src/Specular/Dom/Widgets/Input.purs
+++ b/src/Specular/Dom/Widgets/Input.purs
@@ -31,7 +31,7 @@ import Specular.Dom.Browser as Browser
 import Specular.Dom.Builder.Class (domEventWithSample, elDynAttr', text)
 import Specular.Dom.Node.Class (Attrs, (:=))
 import Specular.Dom.Widget (class MonadWidget)
-import Specular.FRP (class MonadFRP, Dynamic, Event, WeakDynamic, filterEvent, holdDyn, leftmost, never)
+import Specular.FRP (class MonadFRP, Dynamic, Event, WeakDynamic, filterEvent, holdDyn, leftmost, never, subscribeWeakDyn_)
 import Specular.FRP.Base (subscribeEvent_, tagDyn)
 import Unsafe.Coerce (unsafeCoerce)
 
@@ -86,9 +86,11 @@ booleanInputView type_ dchecked dattrs = do
                      ) dattrs dchecked
 
   Tuple node _ <- elDynAttr' "input" dattrs' (pure unit)
+  subscribeWeakDyn_ (setCheckboxChecked node) dchecked
   domEventWithSample (\_ -> getCheckboxChecked node) "change" node
 
 foreign import getCheckboxChecked :: Node -> Effect Boolean
+foreign import setCheckboxChecked :: Node -> Boolean -> Effect Unit
 
 type TextInputConfig =
   { initialValue :: String

--- a/test/browser/InputWidgetsSpec.js
+++ b/test/browser/InputWidgetsSpec.js
@@ -1,0 +1,5 @@
+exports.triggerNodeClicked = function(node) {
+  return function() {
+    return node.click()
+  };
+};


### PR DESCRIPTION
Checkbox are ignoring value provided as an attribute (via dynamic) as soon as they are touched by the user. This becomes an issue when we want to change checkbox state externally (without user interaction). This patch should solve the issue.