### PR TITLE
Monomorphize and extend Specular.Dom.Element

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,8 @@
     "purescript-generics-rep": "^6.0.0",
     "purescript-debug": "^4.0.0",
     "purescript-foreign-object": "^2.0.0",
-    "purescript-avar": "^3.0.0"
+    "purescript-avar": "^3.0.0",
+    "purescript-contravariant": "^4.0.1"
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",

--- a/psc-package.json
+++ b/psc-package.json
@@ -12,6 +12,7 @@
     "generics-rep",
     "debug",
     "foreign-object",
+    "contravariant",
     "avar",
 
     "psci-support",

--- a/src/Specular/Callback.purs
+++ b/src/Specular/Callback.purs
@@ -1,0 +1,102 @@
+module Specular.Callback
+  ( Callback
+  , mkCallback
+  , newCallback
+
+  , triggerCallback
+  , attachEvent
+  , attachDomEvent
+  , attachDyn
+
+  , contramapCallbackDyn
+  , contramapCallbackDynMaybe
+  , contramapCallbackEffect
+  , nullCallback
+  , dynCallback
+  , mbCallback
+  ) where
+
+import Prelude
+
+import Data.Foldable (traverse_)
+import Data.Functor.Contravariant (class Contravariant)
+import Data.Maybe (Maybe)
+import Effect (Effect)
+import Effect.Class (class MonadEffect)
+import Specular.Dom.Browser (Node)
+import Specular.Dom.Browser as SpecularDom
+import Specular.Dom.Builder.Class (domEventWithSample)
+import Specular.Dom.Node.Class (EventType)
+import Specular.FRP (class MonadFRP, Dynamic, Event, current, newEvent, pull, readBehavior, subscribeDyn_, subscribeEvent_)
+
+-- | A handle that lets the owner trigger some action with payload of type `a`.
+-- | Can be thought of as "inverse of `Event`".
+-- |
+-- | The `Contravariant` instance can be used to map over the payload.
+newtype Callback a = Callback (a -> Effect Unit)
+
+instance contravariantCallback :: Contravariant Callback where
+  cmap f (Callback cb) = Callback (cb <<< f)
+
+instance semigroupCallback :: Semigroup (Callback a) where
+  append (Callback a) (Callback b) = Callback (\x -> a x *> b x)
+
+instance monoidCallback :: Monoid (Callback a) where
+  mempty = nullCallback
+
+-- | Map over the callback payload using a `Dynamic` function.
+-- | The Dynamic value will be read at callback trigger time.
+contramapCallbackDyn :: forall a b. Dynamic (b -> a) -> Callback a -> Callback b
+contramapCallbackDyn fD (Callback cb) = Callback \x -> do
+  f <- pull $ readBehavior $ current fD
+  cb (f x)
+
+-- | Map over the callback payload using a `Dynamic` function. If it returns Nothing, the callback will not be triggered.
+-- | The Dynamic value will be read at callback trigger time.
+contramapCallbackDynMaybe :: forall a b. Dynamic (b -> Maybe a) -> Callback a -> Callback b
+contramapCallbackDynMaybe fD (Callback cb) = Callback \x -> do
+  f <- pull $ readBehavior $ current fD
+  traverse_ cb (f x)
+
+-- | Map over the callback payload using an effectful function.
+-- | The effect will be executed at callback trigger time.
+contramapCallbackEffect :: forall a b. (b -> Effect a) -> Callback a -> Callback b
+contramapCallbackEffect f (Callback cb) = Callback (f >=> cb)
+
+mkCallback :: forall a. (a -> Effect Unit) -> Callback a
+mkCallback = Callback
+
+-- | Create a new (`Event`, `Callback`) pair.
+-- | Firing the callback will cause the event to occur.
+newCallback :: forall m a. MonadEffect m => m { event :: Event a, callback :: Callback a }
+newCallback = map (\{event,fire} -> {event, callback: Callback fire}) newEvent
+
+-- | Trigger the action in Effect.
+triggerCallback :: forall a. Callback a -> a -> Effect Unit
+triggerCallback (Callback cb) = cb
+
+-- | Triger the action each time a given `Event` fires.
+attachEvent :: forall m a. MonadFRP m => Event a -> Callback a -> m Unit
+attachEvent event (Callback cb) = subscribeEvent_ cb event
+
+attachDyn :: forall m a. MonadFRP m => Dynamic a -> Callback a -> m Unit
+attachDyn dyn (Callback cb) = subscribeDyn_ cb dyn
+
+-- | Trigger a callback each time a DOM event fires.
+-- | The payload will be the DOM event. It is advised to `cmap` it to a nicer type.
+attachDomEvent :: forall m. MonadFRP m => EventType -> Node -> Callback SpecularDom.Event -> m Unit
+attachDomEvent eventType node callback = do
+  event <- domEventWithSample pure eventType node
+  attachEvent event callback
+
+-- | A Callback that just ignores the input values.
+nullCallback :: forall a. Callback a
+nullCallback = Callback (\_ -> pure unit)
+
+dynCallback :: forall a. Dynamic (Callback a) -> Callback a
+dynCallback dynCb = Callback \x -> do
+  cb <- pull $ readBehavior $ current dynCb
+  triggerCallback cb x
+
+mbCallback :: forall a. Callback a -> Callback (Maybe a)
+mbCallback (Callback cb) = Callback $ traverse_ cb

--- a/src/Specular/Dom/Element.js
+++ b/src/Specular/Dom/Element.js
@@ -1,0 +1,37 @@
+// _stopPropagation :: EffectFn1 DOM.Event Unit
+exports._stopPropagation = function(event) {
+  event.stopPropagation();
+};
+
+// _addClass :: EffectFn2 Node ClassName Unit
+exports._addClass = function(node, cls) {
+  node.classList.add(cls);
+};
+
+// _removeClass :: EffectFn2 Node ClassName Unit
+exports._removeClass = function(node, cls) {
+  node.classList.remove(cls);
+};
+
+// _initClasses :: EffectFn1 Node (EffectFn1 (Array ClassName) Unit)
+exports._initClasses = function(node) {
+  var currentClassSet = {};
+  return function(classes) {
+    var newClassSet = {};
+    for(var i = 0; i < classes.length; i++) {
+      var class_ = classes[i];
+      newClassSet[class_] = true;
+      if(!currentClassSet[class_]) {
+        node.classList.add(class_);
+      }
+    }
+    var oldClasses = Object.keys(currentClassSet);
+    for(var i = 0; i < oldClasses.length; i++) {
+      var class_ = oldClasses[i];
+      if(!newClassSet[class_]) {
+        node.classList.remove(class_);
+      }
+    }
+    currentClassSet = newClassSet;
+  }
+};

--- a/src/Specular/Dom/Element.purs
+++ b/src/Specular/Dom/Element.purs
@@ -1,49 +1,89 @@
 module Specular.Dom.Element
-  ( module Specular.Dom.Element
-  , module X
+  ( module X
+  , el'
+  , el
+  , el_
+  , Prop(..)
+
+  , attrs
+  , attrsD
+
+  , ClassName
+  , class_
+  , classes
+  , classesD
+  , classWhenD
+  , classUnlessD
   ) where
 
 import Prelude
 
 import Data.Array as Array
+import Data.Functor.Contravariant (cmap)
 import Data.Maybe (Maybe(..))
-import Data.Tuple (Tuple(..), snd)
+import Data.Tuple (Tuple(..))
 import Effect (foreachE)
-import Effect.Uncurried (EffectFn2, mkEffectFn1, mkEffectFn2, runEffectFn1, runEffectFn2)
+import Effect.Uncurried (EffectFn1, EffectFn2, EffectFn4, mkEffectFn1, mkEffectFn2, mkEffectFn4, runEffectFn1, runEffectFn2, runEffectFn4)
 import Foreign.Object as Object
-import Specular.Dom.Browser (Node, appendChild)
-import Specular.Dom.Builder.Class (liftBuilderWithRun)
+import Specular.Callback (Callback, mkCallback, triggerCallback)
+import Specular.Dom.Browser (Node, EventType, appendChild)
+import Specular.Dom.Browser as DOM
+import Specular.Dom.Builder (mkBuilder', runBuilder')
+import Specular.Dom.Builder.Class (BuilderEnv)
 import Specular.Dom.Builder.Class (text, rawHtml) as X
 import Specular.Dom.Node.Class (Attrs, TagName, createElement, removeAttributes, setAttributes)
-import Specular.Dom.Widget (class MonadWidget)
+import Specular.Dom.Widget (Widget)
 import Specular.FRP (Dynamic, readDynamic, _subscribeEvent, changed)
 import Specular.Internal.Effect (DelayedEffects, newRef, readRef, writeRef, pushDelayed)
 
 newtype Prop = Prop (EffectFn2 Node DelayedEffects Unit)
 
-el' :: forall m a. MonadWidget m => TagName -> Array Prop -> m a -> m (Tuple Node a)
-el' tagName props body = liftBuilderWithRun $ mkEffectFn2 \env run -> do
+instance semigroupProp :: Semigroup Prop where
+  append (Prop x) (Prop y) = Prop $ mkEffectFn2 \node cleanups -> do
+                               runEffectFn2 x node cleanups
+                               runEffectFn2 y node cleanups
+
+instance monoidProp :: Monoid Prop where
+  mempty = Prop $ mkEffectFn2 \_ _ -> pure unit
+
+el' :: forall a. TagName -> Array Prop -> Widget a -> Widget (Tuple Node a)
+el' tagName props body = mkBuilder' $ mkEffectFn1 \env -> do
   node <- createElement tagName
-  result <- runEffectFn2 run (env { parent = node }) body
+  result <- runEffectFn4 initElement env node props body
+  pure (Tuple node result)
+
+el :: forall a. TagName -> Array Prop -> Widget a -> Widget a
+el tagName props body = mkBuilder' $ mkEffectFn1 \env -> do
+  node <- createElement tagName
+  runEffectFn4 initElement env node props body
+
+initElement :: forall a. EffectFn4 BuilderEnv Node (Array Prop) (Widget a) a
+initElement = mkEffectFn4 \env node props body -> do
+  result <- runEffectFn2 runBuilder' (env { parent = node }) body
   foreachE props \(Prop prop) ->
     runEffectFn2 prop node env.cleanup
   appendChild node env.parent
-  pure (Tuple node result)
+  pure result
 
-el :: forall m a. MonadWidget m => TagName -> Array Prop -> m a -> m a
-el tagName props body = snd <$> el' tagName props body
-
-el_ :: forall m. MonadWidget m => TagName -> Array Prop -> m Unit
+el_ :: TagName -> Array Prop -> Widget Unit
 el_ tagName props = el tagName props (pure unit)
 
-attr :: Attrs -> Prop
-attr attrs = Prop $ mkEffectFn2 \node _ ->
-  setAttributes node attrs
+-- * Attributes
 
-attrD :: Dynamic Attrs -> Prop
-attrD dynAttrs = Prop $ mkEffectFn2 \node cleanups -> do
+-- | Attach static attributes to the node.
+attrs :: Attrs -> Prop
+attrs a = Prop $ mkEffectFn2 \node _ ->
+  setAttributes node a
+
+-- | Attach a dynamically-changing map of attributes to the node.
+-- |
+-- | The set of attributes must be distinct from the attributes set by other
+-- | uses of `attrs` or `attrsD` on the same element.
+attrsD :: Dynamic Attrs -> Prop
+attrsD dynAttrs = Prop $ mkEffectFn2 \node cleanups -> do
   attrsRef <- newRef Object.empty
   let
+    -- TODO: this could be implemented more efficiently with Brutal Mutability (TM)
     resetAttributes = mkEffectFn1 \newAttrs -> do
       oldAttrs <- readRef attrsRef
       writeRef attrsRef newAttrs
@@ -54,8 +94,84 @@ attrD dynAttrs = Prop $ mkEffectFn2 \node cleanups -> do
       removeAttributes node removed
       setAttributes node changed
 
-  initialAttrs <- readDynamic dynAttrs
-  runEffectFn1 resetAttributes initialAttrs
   unsub <- runEffectFn2 _subscribeEvent (runEffectFn1 resetAttributes) (changed dynAttrs)
   pushDelayed cleanups unsub
+  initialAttrs <- readDynamic dynAttrs
+  runEffectFn1 resetAttributes initialAttrs
+
+-- * Events
+
+on :: EventType -> Callback DOM.Event -> Prop
+on eventType cb = Prop $ mkEffectFn2 \node cleanups -> do
+  _ <- DOM.addEventListener eventType (triggerCallback cb) node
+  -- Note: we don't actually need to detach the listener when cleaning up -
+  -- the node will be removed anyway.
   pure unit
+
+onClick :: Callback DOM.Event -> Prop
+onClick cb = on "click" cb
+
+onClick_ :: Callback Unit -> Prop
+onClick_ = onClick <<< cmap (\_ -> unit)
+
+preventDefault :: Callback DOM.Event
+preventDefault = mkCallback DOM.preventDefault
+
+stopPropagation :: Callback DOM.Event
+stopPropagation = mkCallback (runEffectFn1 _stopPropagation)
+
+foreign import _stopPropagation :: EffectFn1 DOM.Event Unit
+
+-- * CSS classes
+
+type ClassName = String
+
+-- | Attach a single CSS class to the element.
+-- |
+-- | Note: if using this property:
+-- | - the `class` attribute must not be used,
+-- | - the provided class name must be distinct from class names used in other properties from this module.
+class_ :: ClassName -> Prop
+class_ cls = Prop $ mkEffectFn2 \node _ ->
+  runEffectFn2 _addClass node cls
+
+-- | Attach an array of CSS classes to the element.
+-- |
+-- | Note: if using this property:
+-- | - the `class` attribute must not be used,
+-- | - the provided class names must be distinct from class names used in other properties from this module.
+classes :: Array ClassName -> Prop
+classes clss = Prop $ mkEffectFn2 \node _ ->
+  foreachE clss \cls ->
+    runEffectFn2 _addClass node cls
+
+foreign import _addClass :: EffectFn2 Node ClassName Unit
+foreign import _removeClass :: EffectFn2 Node ClassName Unit
+
+-- | Attach a dynamically-changing array of CSS classes to the element.
+-- |
+-- | Note: if using this property:
+-- | - the `class` attribute must not be used,
+-- | - the provided class names must be distinct from class names used in other properties from this module.
+classesD :: Dynamic (Array ClassName) -> Prop
+classesD clssD = Prop $ mkEffectFn2 \node cleanups -> do
+  updateClasses <- runEffectFn1 _initClasses node
+  unsub <- runEffectFn2 _subscribeEvent (runEffectFn1 updateClasses) (changed clssD)
+  pushDelayed cleanups unsub
+  initialClasses <- readDynamic clssD
+  runEffectFn1 updateClasses initialClasses
+
+-- | Initialize an object for tracking changes to a class array. Returns function to update the class list.
+foreign import _initClasses :: EffectFn1 Node (EffectFn1 (Array ClassName) Unit)
+
+-- | Conditionally attach a CSS class to the element. The class will be present if the condition is true.
+-- |
+-- | Note: if using this property:
+-- | - the `class` attribute must not be used,
+-- | - the provided class name must be distinct from class names used in other properties from this module.
+classWhenD :: Dynamic Boolean -> ClassName -> Prop
+classWhenD enabled cls = classesD (enabled <#> if _ then [cls] else [])
+
+-- | `classUnlessD cond` = `classWhenD (not cond)`
+classUnlessD :: Dynamic Boolean -> ClassName -> Prop
+classUnlessD enabled cls = classesD (enabled <#> if _ then [] else [cls])

--- a/src/Specular/Dom/Element/Class.purs
+++ b/src/Specular/Dom/Element/Class.purs
@@ -1,0 +1,27 @@
+module Specular.Dom.Element.Class where
+
+import Prelude
+
+import Data.Tuple (Tuple(..), snd)
+import Effect (foreachE)
+import Effect.Uncurried (mkEffectFn2, runEffectFn2)
+import Specular.Dom.Browser (Node, appendChild)
+import Specular.Dom.Builder.Class (liftBuilderWithRun)
+import Specular.Dom.Element (Prop(..))
+import Specular.Dom.Node.Class (TagName, createElement)
+import Specular.Dom.Widget (class MonadWidget)
+
+el' :: forall m a. MonadWidget m => TagName -> Array Prop -> m a -> m (Tuple Node a)
+el' tagName props body = liftBuilderWithRun $ mkEffectFn2 \env run -> do
+  node <- createElement tagName
+  result <- runEffectFn2 run (env { parent = node }) body
+  foreachE props \(Prop prop) ->
+    runEffectFn2 prop node env.cleanup
+  appendChild node env.parent
+  pure (Tuple node result)
+
+el :: forall m a. MonadWidget m => TagName -> Array Prop -> m a -> m a
+el tagName props body = snd <$> el' tagName props body
+
+el_ :: forall m. MonadWidget m => TagName -> Array Prop -> m Unit
+el_ tagName props = el tagName props (pure unit)

--- a/src/Specular/Dom/Widget.purs
+++ b/src/Specular/Dom/Widget.purs
@@ -5,17 +5,20 @@ module Specular.Dom.Widget (
   , runMainWidgetInBody
 
   , class MonadWidget
+
+  , liftWidget
 ) where
 
 import Prelude
 
-import Effect (Effect)
 import Control.Monad.Replace (class MonadReplace)
 import Data.Tuple (Tuple, fst)
+import Effect (Effect)
 import Specular.Dom.Browser (Node)
-import Specular.Dom.Builder (Builder, runBuilder)
-import Specular.Dom.Builder.Class (class MonadDetach, class MonadDomBuilder)
+import Specular.Dom.Builder (Builder, runBuilder, unBuilder)
+import Specular.Dom.Builder.Class (class MonadDetach, class MonadDomBuilder, liftBuilder)
 import Specular.FRP (class MonadFRP)
+import Specular.Internal.RIO (RIO(..))
 
 type Widget = Builder Node
 
@@ -38,3 +41,7 @@ foreign import documentBody :: Effect Node
 -- A handy alias for all the constraints you'll need
 class (MonadDomBuilder m, MonadFRP m, MonadReplace m, MonadDetach m, Monoid (m Unit)) <= MonadWidget m
 instance monadWidget :: (MonadDomBuilder m, MonadFRP m, MonadReplace m, MonadDetach m, Monoid (m Unit)) => MonadWidget m
+
+-- | Lift a `Widget` into any `MonadWidget` monad.
+liftWidget :: forall m a. MonadDomBuilder m => Widget a -> m a
+liftWidget w = let RIO f = unBuilder w in liftBuilder f

--- a/test/browser/NewBuilderSpec.js
+++ b/test/browser/NewBuilderSpec.js
@@ -1,0 +1,10 @@
+// getElementClasses :: String -> Effect (Array ClassName)
+exports.getElementClasses = function(selector) {
+  return function() {
+    return Array.prototype.slice.call(document.querySelector(selector).classList);
+  };
+};
+
+exports.clearDocument = function() {
+  document.body.innerHTML = '';
+};

--- a/test/browser/NewBuilderSpec.purs
+++ b/test/browser/NewBuilderSpec.purs
@@ -3,40 +3,78 @@ module NewBuilderSpec where
 import Prelude hiding (append)
 
 import Data.Tuple (Tuple(..))
+import Effect (Effect)
 import Specular.Dom.Browser (innerHTML)
-import Specular.Dom.Element (attr, attrD, el, el_, rawHtml, text)
+import Specular.Dom.Element (ClassName, attrs, attrsD, classWhenD, classesD, el, el_, rawHtml, text)
 import Specular.Dom.Node.Class ((:=))
+import Specular.Dom.Widget (runMainWidgetInBody)
 import Specular.FRP (newDynamic)
-import Test.Spec (Spec, describe, it)
+import Test.Spec (Spec, after_, describe, it)
 import Test.Utils (liftEffect, shouldReturn, withLeakCheck)
 import Test.Utils.Dom (T3(..), runBuilderInDiv, runBuilderInDiv')
 
 spec :: Spec Unit
-spec = describe "New Builder (Specular.Dom.Element)" do
-  it "builds static DOM" $ withLeakCheck do
-    Tuple node result <- runBuilderInDiv do
-       el "div" [attr ("class" := "content")] do
-         text "foo"
-         el "span" [] $ text "bar"
-         rawHtml """<p class="foo">Raw</p>"""
-         text "baz"
-       el_ "span" []
+spec =
+  after_ (liftEffect clearDocument) $
+  describe "New Builder (Specular.Dom.Element)" do
+    it "builds static DOM" $ withLeakCheck do
+      Tuple node result <- runBuilderInDiv do
+         el "div" [attrs ("class" := "content")] do
+           text "foo"
+           el "span" [] $ text "bar"
+           rawHtml """<p class="foo">Raw</p>"""
+           text "baz"
+         el_ "span" []
 
-    liftEffect (innerHTML node) `shouldReturn`
-      """<div class="content">foo<span>bar</span><p class="foo">Raw</p>baz</div><span></span>"""
+      liftEffect (innerHTML node) `shouldReturn`
+        """<div class="content">foo<span>bar</span><p class="foo">Raw</p>baz</div><span></span>"""
 
-  it "updates attributes" $ withLeakCheck do
-    {dynamic,set} <- liftEffect $ newDynamic $ "k1" := "v1" <> "k2" := "v2"
-    T3 node result unsub <- runBuilderInDiv' do
-       el_ "div" [attrD dynamic]
+    it "updates attributes" $ withLeakCheck do
+      {dynamic,set} <- liftEffect $ newDynamic $ "k1" := "v1" <> "k2" := "v2"
+      T3 node result unsub <- runBuilderInDiv' do
+         el_ "div" [attrsD dynamic]
 
-    liftEffect (innerHTML node) `shouldReturn`
-      """<div k2="v2" k1="v1"></div>"""
+      liftEffect (innerHTML node) `shouldReturn`
+        """<div k2="v2" k1="v1"></div>"""
 
-    liftEffect $ set $ "k1" := "v1.1" <> "k3" := "v3"
+      liftEffect $ set $ "k1" := "v1.1" <> "k3" := "v3"
 
-    liftEffect (innerHTML node) `shouldReturn`
-      """<div k1="v1.1" k3="v3"></div>"""
+      liftEffect (innerHTML node) `shouldReturn`
+        """<div k1="v1.1" k3="v3"></div>"""
 
-    -- clean up
-    liftEffect unsub
+      -- clean up
+      liftEffect unsub
+
+    describe "classesD" do
+      it "single instance" do
+        {dynamic: d, set} <- newDynamic ["foo", "bar"]
+        liftEffect $ runMainWidgetInBody $ el_ "div" [attrs ("id":="test"), classesD d]
+        liftEffect (getElementClasses "#test") `shouldReturn` ["foo", "bar"]
+        liftEffect $ set ["bar", "baz"]
+        liftEffect (getElementClasses "#test") `shouldReturn` ["bar", "baz"]
+        liftEffect $ set ["bar", "baz"]
+        liftEffect (getElementClasses "#test") `shouldReturn` ["bar", "baz"]
+        liftEffect $ set []
+        liftEffect (getElementClasses "#test") `shouldReturn` []
+
+      it "multiple instances" do
+        {dynamic: d1, set: set_d1} <- newDynamic ["foo"]
+        {dynamic: d2, set: set_d2} <- newDynamic ["bar"]
+        liftEffect $ runMainWidgetInBody $ el_ "div" [attrs ("id":="test"), classesD d1, classesD d2]
+        liftEffect (getElementClasses "#test") `shouldReturn` ["foo", "bar"]
+        liftEffect $ set_d1 ["foo", "baz"]
+        liftEffect (getElementClasses "#test") `shouldReturn` ["foo", "bar", "baz"]
+
+    it "classWhenD" do
+      {dynamic: d, set} <- newDynamic true
+      liftEffect $ runMainWidgetInBody $ el_ "div" [attrs ("id":="test"), classWhenD d "foo"]
+      liftEffect (getElementClasses "#test") `shouldReturn` ["foo"]
+      liftEffect $ set false
+      liftEffect (getElementClasses "#test") `shouldReturn` []
+      liftEffect $ set true
+      liftEffect (getElementClasses "#test") `shouldReturn` ["foo"]
+      liftEffect $ set true
+      liftEffect (getElementClasses "#test") `shouldReturn` ["foo"]
+
+foreign import clearDocument :: Effect Unit
+foreign import getElementClasses :: String -> Effect (Array ClassName)


### PR DESCRIPTION
Added functions for event handling and CSS classes to
`Specular.Dom.Element`.

Polymorphic versions moved to `Specular.Dom.Element.Class`.

Added `liftWidget` utility function.