### PR TITLE
Add Reader functionality to Widget

### DIFF
--- a/src/Specular/Dom/Builder.purs
+++ b/src/Specular/Dom/Builder.purs
@@ -146,7 +146,7 @@ instance monadReplaceBuilder :: MonadReplace (Builder env) where
 
     pure $ Slot { replace, destroy, append }
 
-instance monadDomBuilderBuilder :: MonadDomBuilder (Builder env) where
+instance monadDomBuilderBuilder :: MonadDomBuilder env (Builder env) where
 
   text str = mkBuilder \env -> do
     node <- createTextNode str

--- a/src/Specular/Dom/Builder.purs
+++ b/src/Specular/Dom/Builder.purs
@@ -1,6 +1,7 @@
 module Specular.Dom.Builder (
     Builder
   , runBuilder
+  , local
 ) where
 
 import Prelude
@@ -8,6 +9,7 @@ import Prelude
 import Control.Apply (lift2)
 import Control.Monad.Cleanup (class MonadCleanup, onCleanup)
 import Control.Monad.Reader (ask)
+import Control.Monad.Reader.Class (class MonadAsk, class MonadReader)
 import Control.Monad.Replace (class MonadReplace, Slot(Slot), newSlot)
 import Data.Array as A
 import Data.Maybe (Maybe(..))
@@ -24,44 +26,57 @@ import Specular.Internal.Effect (DelayedEffects, emptyDelayed, modifyRef, newRef
 import Specular.Internal.RIO (RIO(..), rio, runRIO)
 import Specular.Internal.RIO as RIO
 
-newtype Builder node a = Builder (RIO (BuilderEnv node) a)
+newtype Builder env a = Builder (RIO (BuilderEnv env) a)
 
-type BuilderEnv node =
-  { parent :: node
+type BuilderEnv env =
+  { parent :: Node
   , cleanup :: DelayedEffects
+  , userEnv :: env
   }
 
-derive newtype instance functorBuilder :: Functor (Builder node)
-derive newtype instance applyBuilder :: Apply (Builder node)
-derive newtype instance applicativeBuilder :: Applicative (Builder node)
-derive newtype instance bindBuilder :: Bind (Builder node)
-derive newtype instance monadBuilder :: Monad (Builder node)
-derive newtype instance monadEffectBuilder :: MonadEffect (Builder node)
+derive newtype instance functorBuilder :: Functor (Builder env)
+derive newtype instance applyBuilder :: Apply (Builder env)
+derive newtype instance applicativeBuilder :: Applicative (Builder env)
+derive newtype instance bindBuilder :: Bind (Builder env)
+derive newtype instance monadBuilder :: Monad (Builder env)
+derive newtype instance monadEffectBuilder :: MonadEffect (Builder env)
 
-instance monadCleanupBuilder :: MonadCleanup (Builder node) where
+instance monadCleanupBuilder :: MonadCleanup (Builder env) where
   onCleanup action = mkBuilder $ \env -> pushDelayed env.cleanup action
 
-mkBuilder :: forall node a. (BuilderEnv node -> Effect a) -> Builder node a
+instance monadAskBuilder :: MonadAsk env (Builder env) where
+  ask = _.userEnv <$> getEnv
+
+instance monadReaderBuilder :: MonadReader env (Builder env) where
+  local = local
+
+local :: forall e r a. (e -> r) -> Builder r a -> Builder e a
+local fn (Builder x) = Builder $ RIO.local (\env -> env { userEnv = fn env.userEnv }) x
+
+mkBuilder :: forall env a. (BuilderEnv env -> Effect a) -> Builder env a
 mkBuilder = Builder <<< rio
 
-unBuilder :: forall node a. Builder node a -> RIO (BuilderEnv node) a
+unBuilder :: forall env a. Builder env a -> RIO (BuilderEnv env) a
 unBuilder (Builder f) = f
 
-runBuilder :: forall node a. node -> Builder node a -> Effect (Tuple a (Effect Unit))
-runBuilder parent (Builder f) = do
+runBuilder :: forall a. Node -> Builder Unit a -> Effect (Tuple a (Effect Unit))
+runBuilder = runBuilderWithUserEnv unit
+
+runBuilderWithUserEnv :: forall env a. env -> Node -> Builder env a -> Effect (Tuple a (Effect Unit))
+runBuilderWithUserEnv userEnv parent (Builder f) = do
   actionsMutable <- emptyDelayed
-  let env = { parent, cleanup: actionsMutable }
+  let env = { parent, cleanup: actionsMutable, userEnv }
   result <- runRIO env f
   actions <- unsafeFreezeDelayed actionsMutable
   pure (Tuple result (sequenceEffects actions))
 
-getEnv :: forall node. Builder node (BuilderEnv node)
+getEnv :: forall env. Builder env (BuilderEnv env)
 getEnv = Builder ask
 
-setParent :: forall node. node -> BuilderEnv node -> BuilderEnv node
+setParent :: forall env. Node -> BuilderEnv env -> BuilderEnv env
 setParent parent env = env { parent = parent }
 
-instance monadReplaceBuilder :: MonadReplace (Builder Node) where
+instance monadReplaceBuilder :: MonadReplace (Builder env) where
 
   newSlot = do
     env <- getEnv
@@ -73,10 +88,10 @@ instance monadReplaceBuilder :: MonadReplace (Builder Node) where
     cleanupRef <- liftEffect $ newRef (mempty :: Effect Unit)
 
     let
-      replace :: forall a. Builder Node a -> Effect a
+      replace :: forall a. Builder env a -> Effect a
       replace inner = do
         fragment <- createDocumentFragment
-        Tuple result cleanup <- runBuilder fragment inner
+        Tuple result cleanup <- runBuilderWithUserEnv env.userEnv fragment inner
         join $ readRef cleanupRef
 
         m_parent <- parentNode placeholderAfter
@@ -102,10 +117,10 @@ instance monadReplaceBuilder :: MonadReplace (Builder Node) where
       destroy = do
         join $ readRef cleanupRef
 
-      append :: Effect (Slot (Builder Node))
+      append :: Effect (Slot (Builder env))
       append = do
         fragment <- createDocumentFragment
-        Tuple slot cleanup <- runBuilder fragment newSlot
+        Tuple slot cleanup <- runBuilderWithUserEnv env.userEnv fragment newSlot
         modifyRef cleanupRef (_ *> cleanup) -- FIXME: memory leak if the inner slot is destroyed
 
         m_parent <- parentNode placeholderAfter
@@ -122,7 +137,7 @@ instance monadReplaceBuilder :: MonadReplace (Builder Node) where
 
     pure $ Slot { replace, destroy, append }
 
-instance monadDomBuilderBuilder :: MonadDomBuilder (Builder Node) where
+instance monadDomBuilderBuilder :: MonadDomBuilder (Builder env) where
 
   text str = mkBuilder \env -> do
     node <- createTextNode str
@@ -172,7 +187,7 @@ instance monadDomBuilderBuilder :: MonadDomBuilder (Builder Node) where
     Builder $ rio \env ->
       runEffectFn2 fn env (mkEffectFn2 \env' (Builder (RIO m)) -> runEffectFn1 m env')
 
-instance monadDetachBuilder :: MonadDetach (Builder Node) where
+instance monadDetachBuilder :: MonadDetach (Builder env) where
   detach inner = do
     fragment <- liftEffect createDocumentFragment
 

--- a/src/Specular/Dom/Builder.purs
+++ b/src/Specular/Dom/Builder.purs
@@ -146,7 +146,7 @@ instance monadReplaceBuilder :: MonadReplace (Builder env) where
 
     pure $ Slot { replace, destroy, append }
 
-instance monadDomBuilderBuilder :: MonadDomBuilder env (Builder env) where
+instance monadDomBuilderBuilder :: MonadDomBuilder (Builder env) where
 
   text str = mkBuilder \env -> do
     node <- createTextNode str

--- a/src/Specular/Dom/Builder/Class.purs
+++ b/src/Specular/Dom/Builder/Class.purs
@@ -23,7 +23,7 @@ type BuilderEnv env =
   , userEnv :: env
   }
 
-class Monad m <= MonadDomBuilder m where
+class Monad m <= MonadDomBuilder env m | m -> env where
   text :: String -> m Unit
   dynText :: WeakDynamic String -> m Unit
   elDynAttrNS' :: forall a. Maybe Namespace -> TagName -> WeakDynamic Attrs -> m a -> m (Tuple Node a)
@@ -31,36 +31,36 @@ class Monad m <= MonadDomBuilder m where
 
   elAttr :: forall a. TagName -> Attrs -> m a -> m a
 
-  liftBuilder :: forall a. (forall env. EffectFn1 (BuilderEnv env) a) -> m a
-  liftBuilderWithRun :: forall a b. (forall env. EffectFn2 (BuilderEnv env) (EffectFn2 (BuilderEnv env) (m b) b) a) -> m a
+  liftBuilder :: forall a. (EffectFn1 (BuilderEnv env) a) -> m a
+  liftBuilderWithRun :: forall a b. (EffectFn2 (BuilderEnv env) (EffectFn2 (BuilderEnv env) (m b) b) a) -> m a
 
-elDynAttr' :: forall m a. MonadDomBuilder m => String -> WeakDynamic Attrs -> m a -> m (Tuple Node a)
+elDynAttr' :: forall m env a. MonadDomBuilder env m => String -> WeakDynamic Attrs -> m a -> m (Tuple Node a)
 elDynAttr' = elDynAttrNS' Nothing
 
-elDynAttr :: forall m a. MonadDomBuilder m => String -> WeakDynamic Attrs -> m a
+elDynAttr :: forall m env a. MonadDomBuilder env m => String -> WeakDynamic Attrs -> m a
   -> m a
 elDynAttr tagName dynAttrs inner = snd <$> elDynAttr' tagName dynAttrs inner
 
 
-elAttr' :: forall m a. MonadDomBuilder m => String -> Attrs -> m a -> m (Tuple Node a)
+elAttr' :: forall m env a. MonadDomBuilder env m => String -> Attrs -> m a -> m (Tuple Node a)
 elAttr' tagName attrs inner = elDynAttr' tagName (pure attrs) inner
 
-elAttr_ :: forall m. MonadDomBuilder m => String -> Attrs -> m Unit
+elAttr_ :: forall m env. MonadDomBuilder env m => String -> Attrs -> m Unit
 elAttr_ tagName attrs = elAttr tagName attrs (pure unit)
 
 
-el' :: forall m a. MonadDomBuilder m => String -> m a -> m (Tuple Node a)
+el' :: forall m env a. MonadDomBuilder env m => String -> m a -> m (Tuple Node a)
 el' tagName inner = elAttr' tagName mempty inner
 
 
-el :: forall m a. MonadDomBuilder m => String -> m a -> m a
+el :: forall m env a. MonadDomBuilder env m => String -> m a -> m a
 el tagName inner = elAttr tagName mempty inner
 
-el_ :: forall m. MonadDomBuilder m => String -> m Unit
+el_ :: forall m env. MonadDomBuilder env m => String -> m Unit
 el_ tagName = el tagName (pure unit)
 
 
-dynRawHtml :: forall m. MonadDomBuilder m => MonadReplace m => MonadFRP m => WeakDynamic String -> m Unit
+dynRawHtml :: forall m env. MonadDomBuilder env m => MonadReplace m => MonadFRP m => WeakDynamic String -> m Unit
 dynRawHtml dynHtml = weakDynamic_ (rawHtml <$> dynHtml)
 
 
@@ -80,7 +80,7 @@ onDomEvent eventType node handler = do
   unsub <- liftEffect $ addEventListener eventType handler node
   onCleanup unsub
 
-instance monadDomBuilderReaderT :: MonadDomBuilder m => MonadDomBuilder (ReaderT r m) where
+instance monadDomBuilderReaderT :: MonadDomBuilder env m => MonadDomBuilder env (ReaderT r m) where
   text = lift <<< text
   dynText = lift <<< dynText
   elDynAttrNS' ns tag attrs body = ReaderT $ \env -> elDynAttrNS' ns tag attrs $ runReaderT body env

--- a/src/Specular/Dom/Element.purs
+++ b/src/Specular/Dom/Element.purs
@@ -22,13 +22,13 @@ import Specular.Internal.Effect (DelayedEffects, newRef, readRef, writeRef, push
 newtype Prop = Prop (EffectFn2 Node DelayedEffects Unit)
 
 el' :: forall m a. MonadWidget m => TagName -> Array Prop -> m a -> m (Tuple Node a)
-el' tagName props body = liftBuilderWithRun $ mkEffectFn2 \env run -> do
+el' tagName props body = liftBuilderWithRun (mkEffectFn2 \env run -> do
   node <- createElement tagName
   result <- runEffectFn2 run (env { parent = node }) body
   foreachE props \(Prop prop) ->
     runEffectFn2 prop node env.cleanup
   appendChild node env.parent
-  pure (Tuple node result)
+  pure (Tuple node result))
 
 el :: forall m a. MonadWidget m => TagName -> Array Prop -> m a -> m a
 el tagName props body = snd <$> el' tagName props body

--- a/src/Specular/Dom/Element/Class.purs
+++ b/src/Specular/Dom/Element/Class.purs
@@ -12,13 +12,14 @@ import Specular.Dom.Node.Class (TagName, createElement)
 import Specular.Dom.Widget (class MonadWidget)
 
 el' :: forall m a. MonadWidget m => TagName -> Array Prop -> m a -> m (Tuple Node a)
-el' tagName props body = liftBuilderWithRun $ mkEffectFn2 \env run -> do
+el' tagName props body = liftBuilderWithRun (mkEffectFn2 \env run -> do
   node <- createElement tagName
   result <- runEffectFn2 run (env { parent = node }) body
   foreachE props \(Prop prop) ->
     runEffectFn2 prop node env.cleanup
   appendChild node env.parent
   pure (Tuple node result)
+  )
 
 el :: forall m a. MonadWidget m => TagName -> Array Prop -> m a -> m a
 el tagName props body = snd <$> el' tagName props body

--- a/src/Specular/Dom/Widget.purs
+++ b/src/Specular/Dom/Widget.purs
@@ -20,6 +20,7 @@ import Specular.Dom.Builder (Builder, runBuilder, unBuilder)
 import Specular.Dom.Builder.Class (class MonadDetach, class MonadDomBuilder, liftBuilder)
 import Specular.FRP (class MonadFRP)
 import Specular.Internal.RIO (RIO(..))
+import Unsafe.Coerce (unsafeCoerce)
 
 type Widget = RWidget Unit
 
@@ -42,9 +43,9 @@ runMainWidgetInBody widget = do
 foreign import documentBody :: Effect Node
 
 -- A handy alias for all the constraints you'll need
-class (MonadDomBuilder Unit m, MonadFRP m, MonadReplace m, MonadDetach m, Monoid (m Unit)) <= MonadWidget m
-instance monadWidget :: (MonadDomBuilder Unit m, MonadFRP m, MonadReplace m, MonadDetach m, Monoid (m Unit)) => MonadWidget m
+class (MonadDomBuilder m, MonadFRP m, MonadReplace m, MonadDetach m, Monoid (m Unit)) <= MonadWidget m
+instance monadWidget :: (MonadDomBuilder m, MonadFRP m, MonadReplace m, MonadDetach m, Monoid (m Unit)) => MonadWidget m
 
 -- | Lift a `Widget` into any `MonadWidget` monad.
-liftWidget :: forall m env a. MonadDomBuilder env m => RWidget env a -> m a
-liftWidget w = let RIO f = unBuilder w in liftBuilder f
+liftWidget :: forall m a. MonadDomBuilder m => Widget a -> m a
+liftWidget w = let RIO f = unBuilder w in liftBuilder (unsafeCoerce f) -- FIXME TMP

--- a/src/Specular/Dom/Widget.purs
+++ b/src/Specular/Dom/Widget.purs
@@ -1,5 +1,6 @@
 module Specular.Dom.Widget (
     Widget
+  , RWidget
   , runWidgetInNode 
   , runMainWidgetInNode
   , runMainWidgetInBody
@@ -17,7 +18,9 @@ import Specular.Dom.Builder (Builder, runBuilder)
 import Specular.Dom.Builder.Class (class MonadDetach, class MonadDomBuilder)
 import Specular.FRP (class MonadFRP)
 
-type Widget = Builder Node
+type Widget = RWidget Unit
+
+type RWidget = Builder
 
 -- | Runs a widget in the specified parent element. Returns the result and cleanup action.
 runWidgetInNode :: forall a. Node -> Widget a -> Effect (Tuple a (Effect Unit))

--- a/src/Specular/Dom/Widget.purs
+++ b/src/Specular/Dom/Widget.purs
@@ -20,7 +20,6 @@ import Specular.Dom.Builder (Builder, runBuilder, unBuilder)
 import Specular.Dom.Builder.Class (class MonadDetach, class MonadDomBuilder, liftBuilder)
 import Specular.FRP (class MonadFRP)
 import Specular.Internal.RIO (RIO(..))
-import Unsafe.Coerce (unsafeCoerce)
 
 type Widget = RWidget Unit
 
@@ -43,9 +42,9 @@ runMainWidgetInBody widget = do
 foreign import documentBody :: Effect Node
 
 -- A handy alias for all the constraints you'll need
-class (MonadDomBuilder m, MonadFRP m, MonadReplace m, MonadDetach m, Monoid (m Unit)) <= MonadWidget m
-instance monadWidget :: (MonadDomBuilder m, MonadFRP m, MonadReplace m, MonadDetach m, Monoid (m Unit)) => MonadWidget m
+class (MonadDomBuilder Unit m, MonadFRP m, MonadReplace m, MonadDetach m, Monoid (m Unit)) <= MonadWidget m
+instance monadWidget :: (MonadDomBuilder Unit m, MonadFRP m, MonadReplace m, MonadDetach m, Monoid (m Unit)) => MonadWidget m
 
 -- | Lift a `Widget` into any `MonadWidget` monad.
-liftWidget :: forall m a. MonadDomBuilder m => Widget a -> m a
-liftWidget w = let RIO f = unBuilder w in liftBuilder (unsafeCoerce f) -- FIXME TMP
+liftWidget :: forall m env a. MonadDomBuilder env m => RWidget env a -> m a
+liftWidget w = let RIO f = unBuilder w in liftBuilder f

--- a/src/Specular/Dom/Widget.purs
+++ b/src/Specular/Dom/Widget.purs
@@ -15,9 +15,10 @@ import Prelude
 import Control.Monad.Replace (class MonadReplace)
 import Data.Tuple (Tuple, fst)
 import Effect (Effect)
+import Effect.Uncurried (EffectFn1, mkEffectFn1, runEffectFn1)
 import Specular.Dom.Browser (Node)
 import Specular.Dom.Builder (Builder, runBuilder, unBuilder)
-import Specular.Dom.Builder.Class (class MonadDetach, class MonadDomBuilder, liftBuilder)
+import Specular.Dom.Builder.Class (class MonadDetach, class MonadDomBuilder, BuilderEnv, liftBuilder)
 import Specular.FRP (class MonadFRP)
 import Specular.Internal.RIO (RIO(..))
 import Unsafe.Coerce (unsafeCoerce)
@@ -48,4 +49,4 @@ instance monadWidget :: (MonadDomBuilder m, MonadFRP m, MonadReplace m, MonadDet
 
 -- | Lift a `Widget` into any `MonadWidget` monad.
 liftWidget :: forall m a. MonadDomBuilder m => Widget a -> m a
-liftWidget w = let RIO f = unBuilder w in liftBuilder (unsafeCoerce f) -- FIXME TMP
+liftWidget w = let RIO f = unBuilder w in liftBuilder (mkEffectFn1 \env -> runEffectFn1 f (env { userEnv = unit }))

--- a/src/Specular/Dom/Widget.purs
+++ b/src/Specular/Dom/Widget.purs
@@ -20,6 +20,7 @@ import Specular.Dom.Builder (Builder, runBuilder, unBuilder)
 import Specular.Dom.Builder.Class (class MonadDetach, class MonadDomBuilder, liftBuilder)
 import Specular.FRP (class MonadFRP)
 import Specular.Internal.RIO (RIO(..))
+import Unsafe.Coerce (unsafeCoerce)
 
 type Widget = RWidget Unit
 
@@ -47,4 +48,4 @@ instance monadWidget :: (MonadDomBuilder m, MonadFRP m, MonadReplace m, MonadDet
 
 -- | Lift a `Widget` into any `MonadWidget` monad.
 liftWidget :: forall m a. MonadDomBuilder m => Widget a -> m a
-liftWidget w = let RIO f = unBuilder w in liftBuilder f
+liftWidget w = let RIO f = unBuilder w in liftBuilder (unsafeCoerce f) -- FIXME TMP

--- a/src/Specular/FRP/Base.purs
+++ b/src/Specular/FRP/Base.purs
@@ -7,7 +7,7 @@ module Specular.FRP.Base (
   , filterEvent
   , filterMapEvent
 
-  , Pull
+  , module X
   , pull
 
   , Behavior
@@ -73,21 +73,8 @@ import Specular.Internal.RIO (RIO, rio, runRIO)
 import Specular.Internal.RIO as RIO
 import Specular.Internal.UniqueMap.Mutable as UMM
 
--------------------------------------------------
-
--- | Pull is a computation that reads a value given current time.
--- |
--- | Invariant: Pull computations are always idempotent (`forall x :: Pull a. x *> x = x`).
-newtype Pull a = MkPull (RIO Time a)
-
-runPull :: forall a. Time -> Pull a -> Effect a
-runPull time (MkPull x) = runRIO time x
-
-derive newtype instance functorPull :: Functor Pull
-derive newtype instance applyPull :: Apply Pull
-derive newtype instance applicativePull :: Applicative Pull
-derive newtype instance bindPull :: Bind Pull
-derive newtype instance monadPull :: Monad Pull
+import Specular.FRP.Internal.Frame
+import Specular.FRP.Internal.Frame (Pull) as X
 
 getTime :: Pull Time
 getTime =
@@ -146,20 +133,6 @@ pull p = liftEffect do
 
 -------------------------------------------------
 
--- | Computations that occur during a Frame.
---
--- During a frame, no arbitrary effects are performed. Instead they are
--- registered using `effect` to be performed after the frame.
---
--- Frame computations have access to current logical time. See `oncePerFrame`
--- for why this is needed.
-newtype Frame a = Frame (RIO FrameEnv a)
-
-type FrameEnv =
-  { effects :: DelayedEffects
-  , time :: Time
-  }
-
 framePull :: forall a. Pull a -> Frame a
 framePull (MkPull x) = Frame (RIO.local _.time x)
 
@@ -175,12 +148,6 @@ effect action = Frame $ rio $ \{effects} ->
   -- HACK: briefly creating a Pull that is not idempotent;
   -- But it's immediately lifted to Frame, so it's OK
   void $ pushDelayed effects action
-
-derive newtype instance functorFrame :: Functor Frame
-derive newtype instance applyFrame :: Apply Frame
-derive newtype instance applicativeFrame :: Applicative Frame
-derive newtype instance bindFrame :: Bind Frame
-derive newtype instance monadFrame :: Monad Frame
 
 -- | Run a Frame computation and then run its effects.
 runFrame :: forall a. Time -> Frame a -> Effect a
@@ -219,12 +186,6 @@ oncePerFrame_ action = do
         action
 
 -------------------------------------------------------------
-
--- | Logical time.
--- There's no monotonicity requirement (for now), so we have only Eq instance.
-newtype Time = Time Int
-
-derive newtype instance eqTime :: Eq Time
 
 -- | The global time counter.
 nextTimeRef :: Ref Time
@@ -508,7 +469,7 @@ foldDynImpl f initial (Event event) = do
     }
 
 -- | Construct a new root Dynamic that can be changed from `Effect`-land.
-newDynamic :: forall m a. MonadEffect m => a -> m { dynamic :: Dynamic a, read :: Effect a, set :: a -> Effect Unit }
+newDynamic :: forall m a. MonadEffect m => a -> m { dynamic :: Dynamic a, read :: Effect a, set :: a -> Effect Unit, modify :: (a -> a) -> Effect Unit }
 newDynamic initial = liftEffect do
   change <- newEvent
   ref <- newRef initial
@@ -520,6 +481,9 @@ newDynamic initial = liftEffect do
     , read: readRef ref
     , set: \x -> do
         writeRef ref x
+        change.fire unit
+    , modify: \f -> do
+        modifyRef ref f
         change.fire unit
     }
 

--- a/src/Specular/FRP/Internal/Frame.purs
+++ b/src/Specular/FRP/Internal/Frame.purs
@@ -1,0 +1,69 @@
+module Specular.FRP.Internal.Frame where
+
+import Prelude
+
+import Control.Apply (lift2)
+import Control.Monad.Cleanup (class MonadCleanup, onCleanup)
+import Control.Monad.Reader (ask)
+import Control.Monad.Rec.Class (Step(..), tailRecM)
+import Data.Array (cons, unsnoc)
+import Data.Array as Array
+import Data.Foldable (for_)
+import Data.HeytingAlgebra (ff, implies, tt)
+import Data.Maybe (Maybe(..), isJust)
+import Data.Traversable (sequence, traverse)
+import Effect (Effect)
+import Effect.Class (class MonadEffect, liftEffect)
+import Effect.Uncurried (EffectFn2, mkEffectFn2, runEffectFn2)
+import Effect.Unsafe (unsafePerformEffect)
+import Partial.Unsafe (unsafeCrashWith)
+import Specular.Internal.Effect (DelayedEffects, Ref, emptyDelayed, modifyRef, newRef, pushDelayed, readRef, sequenceEffects, unsafeFreezeDelayed, writeRef)
+import Specular.Internal.RIO (RIO, rio, runRIO)
+import Specular.Internal.RIO as RIO
+import Specular.Internal.UniqueMap.Mutable as UMM
+
+-------------------------------------------------
+
+-- | Logical time.
+-- There's no monotonicity requirement (for now), so we have only Eq instance.
+newtype Time = Time Int
+
+derive newtype instance eqTime :: Eq Time
+
+-- | Pull is a computation that reads a value given current time.
+-- |
+-- | Invariant: Pull computations are always idempotent (`forall x :: Pull a. x *> x = x`).
+newtype Pull a = MkPull (RIO Time a)
+
+runPull :: forall a. Time -> Pull a -> Effect a
+runPull time (MkPull x) = runRIO time x
+
+derive newtype instance functorPull :: Functor Pull
+derive newtype instance applyPull :: Apply Pull
+derive newtype instance applicativePull :: Applicative Pull
+derive newtype instance bindPull :: Bind Pull
+derive newtype instance monadPull :: Monad Pull
+
+
+
+-- | Computations that occur during a Frame.
+--
+-- During a frame, no arbitrary effects are performed. Instead they are
+-- registered using `effect` to be performed after the frame.
+--
+-- Frame computations have access to current logical time. See `oncePerFrame`
+-- for why this is needed.
+newtype Frame a = Frame (RIO FrameEnv a)
+
+type FrameEnv =
+  { effects :: DelayedEffects
+  , time :: Time
+  }
+
+
+
+derive newtype instance functorFrame :: Functor Frame
+derive newtype instance applyFrame :: Apply Frame
+derive newtype instance applicativeFrame :: Applicative Frame
+derive newtype instance bindFrame :: Bind Frame
+derive newtype instance monadFrame :: Monad Frame


### PR DESCRIPTION
We introduce a new type - `RWidget env` - which is like Widget, but carries an environment of type `Env`.
Has `MonadAsk` and `MonadReader` instance.

Helpful for transitioning existing code operating in `ReaderT Widget` stack into just `Widget`.