### PR TITLE
subscribeEvent: Use a mutable queue instead of an immutable array ref

### DIFF
--- a/src/Specular/Internal/Queue.js
+++ b/src/Specular/Internal/Queue.js
@@ -1,0 +1,23 @@
+// foreign import new :: forall a. Effect (Queue a)
+exports.new = function() {
+  return {
+    elements: [],
+    first: 0,
+  };
+};
+
+// foreign import enqueue :: forall a. EffectFn2 (Queue a) a Unit
+exports.enqueue = function(q, elem) {
+  q.elements.push(elem);
+};
+
+// foreign import drain :: forall a. EffectFn2 (Queue a) (EffectFn1 a Unit) Unit
+exports.drain = function(q, fn) {
+  while(q.first < q.elements.length) {
+    var elem = q.elements[q.first];
+    q.first++;
+    fn(elem);
+  }
+  q.elements = [];
+  q.first = 0;
+};

--- a/src/Specular/Internal/Queue.purs
+++ b/src/Specular/Internal/Queue.purs
@@ -1,0 +1,26 @@
+module Specular.Internal.Queue where
+
+import Prelude
+
+import Effect (Effect)
+import Effect.Uncurried (EffectFn1, EffectFn2)
+
+-- | A mutable FIFO queue.
+foreign import data Queue :: Type -> Type
+
+-- | Create a new empty queue.
+foreign import new :: forall a. Effect (Queue a)
+
+-- | Add an element onto the end of the queue.
+foreign import enqueue :: forall a. EffectFn2 (Queue a) a Unit
+
+-- | Iterate over the queue, calling the specified function on each element in sequence.
+-- |
+-- | Postcondition: When `drain` returns, the queue is empty.
+-- |
+-- | If the function calls `enqueue`, the newly added elements will be processed in the run of `drain`.
+-- |
+-- | If the function calls `drain`, the inner `drain` will consume all elements
+-- | and it will be the last invocation of the callback function in the outer
+-- | `drain`.
+foreign import drain :: forall a. EffectFn2 (Queue a) (EffectFn1 a Unit) Unit


### PR DESCRIPTION
```
Before:
------ Dynamic
10 subscribers: 35.72 us
20 subscribers: 71.42 us
30 subscribers: 103.415 us
40 subscribers: 133.87 us
dyn: 4.935 us
dyn fmap: 5.025 us
dyn ap pure: 6.22 us
dyn ap self: 7.12 us
dyn bind self: 10.05 us
dyn bind inner: 7.07 us
dyn bind outer: 9.105 us
dyn 1ap  - fire first: 6.985 us
dyn 5ap  - fire first: 12.875 us
dyn 10ap - fire first: 20.085 us
dyn 15ap - fire first: 27.055 us
dyn 1ap  - fire last: 6.97 us
dyn 5ap  - fire last: 13.47 us
dyn 10ap - fire last: 20.935 us
dyn 15ap - fire last: 27.84 us

After:
------ Dynamic
10 subscribers: 21.75 us
20 subscribers: 43.68 us
30 subscribers: 65.105 us
40 subscribers: 84.345 us
dyn: 3.385 us
dyn fmap: 3.51 us
dyn ap pure: 4.515 us
dyn ap self: 5.145 us
dyn bind self: 7.95 us
dyn bind inner: 5.245 us
dyn bind outer: 6.885 us
dyn 1ap  - fire first: 5.1 us
dyn 5ap  - fire first: 10.985 us
dyn 10ap - fire first: 18.115 us
dyn 15ap - fire first: 25.03 us
dyn 1ap  - fire last: 5.295 us
dyn 5ap  - fire last: 11.47 us
dyn 10ap - fire last: 18.76 us
dyn 15ap - fire last: 25.91 us
```