### PR TITLE
Add convenience functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 ## Next release
 
+- 2019-10-30 Add a number of convenience functions:
+   * `Specular.Callback`
+     * `contramapCallbackDyn_`
+   * `Specular.Dom.Element`
+     *  `dynText`
+     *  `attr`
+     *  `attrWhen`
+     *  `attrUnless`
+     *  `attrWhenD`
+     *  `attrUnlessD`
+     *  `attrsD`
+     *  `attrsWhen`
+     *  `attrsUnless`
+     *  `attrsWhenD`
+     *  `attrsUnlessD`
+     *  `classWhen`
+     *  `classUnless`
+   * `Specular.Dom.Widget`
+     * `emptyWidget`
+   * `Specular.FRP.Base`
+     * `filterJustEvent`
+     * `uniqDyn`
+   * `Specular.FRP.Replacable`
+     * `withDynamic_`
+     * `whenJustD`
+     * `whenD`
+     * `unlessD`
 - 2019-10-28 Added `Specular.Ref`
 - 2019-10-24 Use a mutable queue instead of an immutable array ref
 

--- a/src/Specular/Callback.purs
+++ b/src/Specular/Callback.purs
@@ -9,6 +9,7 @@ module Specular.Callback
   , attachDyn
 
   , contramapCallbackDyn
+  , contramapCallbackDyn_
   , contramapCallbackDynMaybe
   , contramapCallbackEffect
   , nullCallback
@@ -50,6 +51,11 @@ contramapCallbackDyn :: forall a b. Dynamic (b -> a) -> Callback a -> Callback b
 contramapCallbackDyn fD (Callback cb) = Callback \x -> do
   f <- pull $ readBehavior $ current fD
   cb (f x)
+
+contramapCallbackDyn_ :: forall a b. Dynamic a -> Callback a -> Callback b
+contramapCallbackDyn_ fD (Callback cb) = Callback \_ -> do
+  f <- pull $ readBehavior $ current fD
+  cb f
 
 -- | Map over the callback payload using a `Dynamic` function. If it returns Nothing, the callback will not be triggered.
 -- | The Dynamic value will be read at callback trigger time.

--- a/src/Specular/Callback.purs
+++ b/src/Specular/Callback.purs
@@ -28,7 +28,7 @@ import Specular.Dom.Browser (Node)
 import Specular.Dom.Browser as SpecularDom
 import Specular.Dom.Builder.Class (domEventWithSample)
 import Specular.Dom.Node.Class (EventType)
-import Specular.FRP (class MonadFRP, Dynamic, Event, current, newEvent, pull, readBehavior, subscribeDyn_, subscribeEvent_)
+import Specular.FRP (class MonadFRP, Dynamic, Event, current, newEvent, pull, readBehavior, readDynamic, subscribeDyn_, subscribeEvent_)
 
 -- | A handle that lets the owner trigger some action with payload of type `a`.
 -- | Can be thought of as "inverse of `Event`".
@@ -49,19 +49,19 @@ instance monoidCallback :: Monoid (Callback a) where
 -- | The Dynamic value will be read at callback trigger time.
 contramapCallbackDyn :: forall a b. Dynamic (b -> a) -> Callback a -> Callback b
 contramapCallbackDyn fD (Callback cb) = Callback \x -> do
-  f <- pull $ readBehavior $ current fD
+  f <- readDynamic fD
   cb (f x)
 
 contramapCallbackDyn_ :: forall a b. Dynamic a -> Callback a -> Callback b
 contramapCallbackDyn_ fD (Callback cb) = Callback \_ -> do
-  f <- pull $ readBehavior $ current fD
+  f <- readDynamic fD
   cb f
 
 -- | Map over the callback payload using a `Dynamic` function. If it returns Nothing, the callback will not be triggered.
 -- | The Dynamic value will be read at callback trigger time.
 contramapCallbackDynMaybe :: forall a b. Dynamic (b -> Maybe a) -> Callback a -> Callback b
 contramapCallbackDynMaybe fD (Callback cb) = Callback \x -> do
-  f <- pull $ readBehavior $ current fD
+  f <- readDynamic fD
   traverse_ cb (f x)
 
 -- | Map over the callback payload using an effectful function.
@@ -101,7 +101,7 @@ nullCallback = Callback (\_ -> pure unit)
 
 dynCallback :: forall a. Dynamic (Callback a) -> Callback a
 dynCallback dynCb = Callback \x -> do
-  cb <- pull $ readBehavior $ current dynCb
+  cb <- readDynamic dynCb
   triggerCallback cb x
 
 mbCallback :: forall a. Callback a -> Callback (Maybe a)

--- a/src/Specular/Dom/Element.purs
+++ b/src/Specular/Dom/Element.purs
@@ -33,6 +33,8 @@ module Specular.Dom.Element
   , classesD
   , classWhenD
   , classUnlessD
+  , classWhen
+  , classUnless
   ) where
 
 import Prelude
@@ -139,6 +141,9 @@ type AttrValue = String
 attr :: AttrName -> AttrValue -> Prop
 attr name value = attrs (name := value)
 
+attrD :: AttrName -> Dynamic AttrValue -> Prop
+attrD name valueD = attrsD $ valueD <#> (name := _)
+
 attrWhen :: Boolean -> AttrName -> AttrValue -> Prop
 attrWhen true attrName attrValue = attr attrName attrValue
 attrWhen false _ _ = mempty
@@ -243,3 +248,9 @@ classWhenD enabled cls = classesD (enabled <#> if _ then [cls] else [])
 -- | `classUnlessD cond` = `classWhenD (not cond)`
 classUnlessD :: Dynamic Boolean -> ClassName -> Prop
 classUnlessD enabled cls = classesD (enabled <#> if _ then [] else [cls])
+
+classWhen :: Boolean -> ClassName -> Prop
+classWhen enabled cls = if enabled then class_ cls else mempty
+
+classUnless :: Boolean -> ClassName -> Prop
+classUnless enabled cls = if enabled then mempty else class_ cls

--- a/src/Specular/Dom/Element.purs
+++ b/src/Specular/Dom/Element.purs
@@ -6,9 +6,20 @@ module Specular.Dom.Element
   , Prop(..)
 
   , text
+  , dynText
+
+  , attr
+  , attrWhen
+  , attrUnless
+  , attrWhenD
+  , attrUnlessD
 
   , attrs
   , attrsD
+  , attrsWhen
+  , attrsUnless
+  , attrsWhenD
+  , attrsUnlessD
 
   , on
   , onClick
@@ -34,14 +45,14 @@ import Effect (foreachE)
 import Effect.Uncurried (EffectFn1, EffectFn2, EffectFn4, mkEffectFn1, mkEffectFn2, mkEffectFn4, runEffectFn1, runEffectFn2, runEffectFn4)
 import Foreign.Object as Object
 import Specular.Callback (Callback, mkCallback, triggerCallback)
-import Specular.Dom.Browser (EventType, Node, appendChild, createTextNode)
+import Specular.Dom.Browser (EventType, Node, appendChild, createTextNode, setText, (:=))
 import Specular.Dom.Browser as DOM
 import Specular.Dom.Builder (mkBuilder', runBuilder')
 import Specular.Dom.Builder.Class (BuilderEnv)
 import Specular.Dom.Builder.Class (rawHtml) as X
 import Specular.Dom.Node.Class (Attrs, TagName, createElement, removeAttributes, setAttributes)
 import Specular.Dom.Widget (RWidget)
-import Specular.FRP (Dynamic, readDynamic, _subscribeEvent, changed)
+import Specular.FRP (Dynamic, _subscribeEvent, changed, readDynamic, subscribeDyn_)
 import Specular.Internal.Effect (DelayedEffects, newRef, readRef, writeRef, pushDelayed)
 
 newtype Prop = Prop (EffectFn2 Node DelayedEffects Unit)
@@ -83,6 +94,14 @@ text str = mkBuilder' $ mkEffectFn1 \env -> do
   node <- createTextNode str
   appendChild node env.parent
 
+dynText :: forall r. Dynamic String -> RWidget r Unit
+dynText strD = do
+  node <- mkBuilder' $ mkEffectFn1 \env -> do
+    node <- createTextNode ""
+    appendChild node env.parent
+    pure node
+  subscribeDyn_ (setText node) strD
+
 -- * Attributes
 
 -- | Attach static attributes to the node.
@@ -113,6 +132,40 @@ attrsD dynAttrs = Prop $ mkEffectFn2 \node cleanups -> do
   pushDelayed cleanups unsub
   initialAttrs <- readDynamic dynAttrs
   runEffectFn1 resetAttributes initialAttrs
+
+type AttrName = String
+type AttrValue = String
+
+attr :: AttrName -> AttrValue -> Prop
+attr name value = attrs (name := value)
+
+attrWhen :: Boolean -> AttrName -> AttrValue -> Prop
+attrWhen true attrName attrValue = attr attrName attrValue
+attrWhen false _ _ = mempty
+
+attrUnless :: Boolean -> AttrName -> AttrValue -> Prop
+attrUnless false attrName attrValue = attr attrName attrValue
+attrUnless true _ _ = mempty
+
+attrsWhen :: Boolean -> Attrs -> Prop
+attrsWhen true = attrs
+attrsWhen false = mempty
+
+attrsUnless :: Boolean -> Attrs -> Prop
+attrsUnless false = attrs
+attrsUnless true = mempty
+
+attrWhenD :: Dynamic Boolean -> AttrName -> AttrValue -> Prop
+attrWhenD conditionD name value = attrsD $ conditionD <#> if _ then name := value else mempty
+
+attrUnlessD :: Dynamic Boolean -> AttrName -> AttrValue -> Prop
+attrUnlessD conditionD name value = attrsD $ conditionD <#> if _ then mempty else name := value
+
+attrsWhenD :: Dynamic Boolean -> Attrs -> Prop
+attrsWhenD conditionD attrs' = attrsD $ conditionD <#> if _ then attrs' else mempty
+
+attrsUnlessD :: Dynamic Boolean -> Attrs -> Prop
+attrsUnlessD conditionD attrs' = attrsD $ conditionD <#> if _ then mempty else attrs'
 
 -- * Events
 

--- a/src/Specular/Dom/Widget.purs
+++ b/src/Specular/Dom/Widget.purs
@@ -1,13 +1,14 @@
 module Specular.Dom.Widget (
     Widget
   , RWidget
-  , runWidgetInNode 
+  , runWidgetInNode
   , runMainWidgetInNode
   , runMainWidgetInBody
 
   , class MonadWidget
 
   , liftWidget
+  , emptyWidget
 ) where
 
 import Prelude
@@ -15,13 +16,12 @@ import Prelude
 import Control.Monad.Replace (class MonadReplace)
 import Data.Tuple (Tuple, fst)
 import Effect (Effect)
-import Effect.Uncurried (EffectFn1, mkEffectFn1, runEffectFn1)
+import Effect.Uncurried (mkEffectFn1, runEffectFn1)
 import Specular.Dom.Browser (Node)
 import Specular.Dom.Builder (Builder, runBuilder, unBuilder)
-import Specular.Dom.Builder.Class (class MonadDetach, class MonadDomBuilder, BuilderEnv, liftBuilder)
+import Specular.Dom.Builder.Class (class MonadDetach, class MonadDomBuilder, liftBuilder)
 import Specular.FRP (class MonadFRP)
 import Specular.Internal.RIO (RIO(..))
-import Unsafe.Coerce (unsafeCoerce)
 
 type Widget = RWidget Unit
 
@@ -50,3 +50,6 @@ instance monadWidget :: (MonadDomBuilder m, MonadFRP m, MonadReplace m, MonadDet
 -- | Lift a `Widget` into any `MonadWidget` monad.
 liftWidget :: forall m a. MonadDomBuilder m => Widget a -> m a
 liftWidget w = let RIO f = unBuilder w in liftBuilder (mkEffectFn1 \env -> runEffectFn1 f (env { userEnv = unit }))
+
+emptyWidget :: Widget Unit
+emptyWidget = pure unit

--- a/src/Specular/FRP/Base.purs
+++ b/src/Specular/FRP/Base.purs
@@ -6,6 +6,7 @@ module Specular.FRP.Base (
 
   , filterEvent
   , filterMapEvent
+  , filterJustEvent
 
   , module X
   , pull
@@ -30,6 +31,7 @@ module Specular.FRP.Base (
   , foldDynMaybe
   , holdUniqDynBy
   , uniqDynBy
+  , uniqDyn
 
   , newEvent
   , newBehavior
@@ -215,7 +217,7 @@ type Unsubscribe = Effect Unit
 -- | A source of occurences.
 -- |
 -- | During a frame, an Event occurs at most once with a value of type a.
--- | 
+-- |
 -- | Event is a functor. It is not, however, an Applicative. There is no
 -- | meaningful interpretation of `pure` (when would the event occur?).
 -- | There is an interpretation of `apply` (Event that fires when the input
@@ -267,6 +269,9 @@ filterMapEvent f = filterMapEventB (pure <<< f)
 
 filterEvent :: forall a. (a -> Boolean) -> Event a -> Event a
 filterEvent f = filterMapEvent (\x -> if f x then Just x else Nothing)
+
+filterJustEvent :: forall a. Event (Maybe a) -> Event a
+filterJustEvent = filterMapEvent identity
 
 mergeEvents ::
      forall a b c
@@ -514,6 +519,9 @@ uniqDynBy :: forall m a. MonadFRP m => (a -> a -> Boolean) -> Dynamic a -> m (Dy
 uniqDynBy eq dyn = do
   initialValue <- pull $ readBehavior $ current dyn
   holdUniqDynBy eq initialValue (changed dyn)
+
+uniqDyn :: forall m a. MonadFRP m => Eq a => Dynamic a -> m (Dynamic a)
+uniqDyn = uniqDynBy (==)
 
 -- | Make an Event that occurs when the current value of the given Dynamic (an Event) occurs.
 switch :: forall a. Dynamic (Event a) -> Event a

--- a/src/Specular/FRP/Replaceable.purs
+++ b/src/Specular/FRP/Replaceable.purs
@@ -3,13 +3,20 @@ module Specular.FRP.Replaceable where
 import Prelude
 
 import Control.Monad.Replace (class MonadReplace, Slot(Slot), newSlot)
-import Specular.FRP.Base (class MonadFRP, Dynamic, subscribeDyn, subscribeDyn_)
+import Data.Maybe (Maybe(..), fromMaybe, isJust)
+import Partial.Unsafe (unsafeCrashWith)
+import Specular.FRP.Base (class MonadFRP, Dynamic, changed, filterJustEvent, newDynamic, readDynamic, subscribeDyn, subscribeDyn_, subscribeEvent_, uniqDynBy)
 import Specular.FRP.WeakDynamic (WeakDynamic, subscribeWeakDyn, subscribeWeakDyn_)
 
 dynamic_ :: forall m. MonadReplace m => MonadFRP m => Dynamic (m Unit) -> m Unit
 dynamic_ dyn = do
   Slot {replace} <- newSlot
   subscribeDyn_ (\x -> replace x) dyn
+
+withDynamic_ :: forall m a. MonadReplace m => MonadFRP m => Dynamic a -> (a -> m Unit) -> m Unit
+withDynamic_ dyn widget = do
+  Slot {replace} <- newSlot
+  subscribeDyn_ (\x -> replace (widget x)) dyn
 
 dynamic :: forall m a. MonadReplace m => MonadFRP m => Dynamic (m a) -> m (Dynamic a)
 dynamic dyn = do
@@ -25,3 +32,27 @@ weakDynamic :: forall m a. MonadReplace m => MonadFRP m => WeakDynamic (m a) -> 
 weakDynamic dyn = do
   Slot {replace} <- newSlot
   subscribeWeakDyn (\x -> replace x) dyn
+
+whenJustD :: forall m a. MonadReplace m => MonadFRP m => Dynamic (Maybe a) -> (Dynamic a -> m Unit) -> m Unit
+whenJustD dyn widget = do
+  shouldDisplay <- uniqDynBy eq (isJust <$> dyn)
+  whenD shouldDisplay do
+    dynVal <- readDynamic dyn
+    case dynVal of
+      Just dynVal' -> do
+        dyn' <- newDynamic dynVal'
+        subscribeEvent_ dyn'.set $ filterJustEvent $ changed dyn
+        widget dyn'.dynamic
+      Nothing -> pure unit
+
+-- | Execute a monadic action in a Replaceable monad only if the given Dynamic
+-- | has value `true`.
+whenD :: forall m. MonadFRP m => MonadReplace m => Dynamic Boolean -> m Unit -> m Unit
+whenD dyn block =
+  dynamic_ $ dyn <#> \value -> when value block
+
+-- | Execute a monadic action in a Replaceable monad only if the given Dynamic
+-- | has value `true`.
+unlessD :: forall m. MonadFRP m => MonadReplace m => Dynamic Boolean -> m Unit -> m Unit
+unlessD dyn block =
+  dynamic_ $ dyn <#> \value -> unless value block

--- a/src/Specular/FRP/Replaceable.purs
+++ b/src/Specular/FRP/Replaceable.purs
@@ -5,7 +5,7 @@ import Prelude
 import Control.Monad.Replace (class MonadReplace, Slot(Slot), newSlot)
 import Data.Maybe (Maybe(..), fromMaybe, isJust)
 import Partial.Unsafe (unsafeCrashWith)
-import Specular.FRP.Base (class MonadFRP, Dynamic, changed, filterJustEvent, newDynamic, readDynamic, subscribeDyn, subscribeDyn_, subscribeEvent_, uniqDynBy)
+import Specular.FRP.Base (class MonadFRP, Dynamic, changed, filterJustEvent, newDynamic, readDynamic, subscribeDyn, subscribeDyn_, subscribeEvent_, uniqDyn, uniqDynBy)
 import Specular.FRP.WeakDynamic (WeakDynamic, subscribeWeakDyn, subscribeWeakDyn_)
 
 dynamic_ :: forall m. MonadReplace m => MonadFRP m => Dynamic (m Unit) -> m Unit
@@ -48,11 +48,13 @@ whenJustD dyn widget = do
 -- | Execute a monadic action in a Replaceable monad only if the given Dynamic
 -- | has value `true`.
 whenD :: forall m. MonadFRP m => MonadReplace m => Dynamic Boolean -> m Unit -> m Unit
-whenD dyn block =
-  dynamic_ $ dyn <#> \value -> when value block
+whenD dyn block = do
+  dyn' <- uniqDyn dyn
+  dynamic_ $ dyn' <#> \value -> when value block
 
 -- | Execute a monadic action in a Replaceable monad only if the given Dynamic
 -- | has value `true`.
 unlessD :: forall m. MonadFRP m => MonadReplace m => Dynamic Boolean -> m Unit -> m Unit
-unlessD dyn block =
-  dynamic_ $ dyn <#> \value -> unless value block
+unlessD dyn block = do
+  dyn' <- uniqDyn dyn
+  dynamic_ $ dyn' <#> \value -> unless value block

--- a/test/browser/BuilderSpec.purs
+++ b/test/browser/BuilderSpec.purs
@@ -8,13 +8,14 @@ import Data.Tuple (Tuple(..))
 import Effect (Effect)
 import Specular.Dom.Browser (innerHTML)
 import Specular.Dom.Builder.Class (detach, domEventWithSample, el, elAttr, elDynAttr, elDynAttr', elDynAttrNS', rawHtml, text)
+import Specular.Dom.Element (dynText)
 import Specular.Dom.Node.Class ((:=))
 import Specular.Dom.Widgets.Button (buttonOnClick)
-import Specular.FRP (Dynamic, Event, WeakDynamic, dynamic_, never, subscribeEvent_, switch, weaken)
+import Specular.FRP (Dynamic, Event, WeakDynamic, dynamic_, never, subscribeEvent_, switch, weaken, whenJustD)
 import Specular.FRP as FRP
 import Specular.FRP.Replaceable (dynamic, weakDynamic)
 import Specular.FRP.WeakDynamic (switchWeakDyn)
-import Specular.Internal.Effect (newRef)
+import Specular.Internal.Effect (modifyRef, newRef)
 import Test.Spec (Spec, describe, it)
 import Test.Spec.Assertions (shouldEqual)
 import Test.Utils (append, liftEffect, shouldHaveValue, shouldReturn, withLeakCheck)
@@ -157,6 +158,94 @@ spec = describe "Builder" $ do
 
       -- clean up
       liftEffect unsub
+
+
+  describe "whenJustD" $ do
+    it "renders empty when dynamic is initially Nothing" $ withLeakCheck $ do
+      Tuple dynMb _  <- liftEffect $ newDynamic Nothing
+      T3 node _ unsub <- runBuilderInDiv' $ do
+        elDynAttr "span" (pure mempty) $ pure unit
+        whenJustD dynMb $ \dyn -> dynText dyn
+        elDynAttr "span" (pure mempty) $ pure unit
+
+      liftEffect (innerHTML node) `shouldReturn`
+        """<span></span><span></span>"""
+
+      -- clean up
+      liftEffect unsub
+
+    it "renders contents when dynamic is initially Just" $ withLeakCheck $ do
+      Tuple dynMb _  <- liftEffect $ newDynamic $ Just "foobar"
+      T3 node _ unsub <- runBuilderInDiv' $ do
+        elDynAttr "span" (pure mempty) $ pure unit
+        whenJustD dynMb $ \dyn -> dynText dyn
+        elDynAttr "span" (pure mempty) $ pure unit
+
+      liftEffect (innerHTML node) `shouldReturn`
+        """<span></span>foobar<span></span>"""
+
+      -- clean up
+      liftEffect unsub
+
+    it "renders contents when dynamic is initially Nothing then updated to Just" $ withLeakCheck $ do
+      Tuple dynMb updateDyn  <- liftEffect $ newDynamic $ Nothing
+      T3 node _ unsub <- runBuilderInDiv' $ do
+        elDynAttr "span" (pure mempty) $ pure unit
+        whenJustD dynMb $ \dyn -> dynText dyn
+        elDynAttr "span" (pure mempty) $ pure unit
+
+      liftEffect (innerHTML node) `shouldReturn`
+        """<span></span><span></span>"""
+
+      liftEffect $ updateDyn $ Just "foobar"
+      liftEffect (innerHTML node) `shouldReturn`
+        """<span></span>foobar<span></span>"""
+
+      -- clean up
+      liftEffect unsub
+
+    it "renders empty when dynamic is initially Just then updated to Nothing" $ withLeakCheck $ do
+      Tuple dynMb updateDyn  <- liftEffect $ newDynamic $ Just "foobar"
+      T3 node _ unsub <- runBuilderInDiv' $ do
+        elDynAttr "span" (pure mempty) $ pure unit
+        whenJustD dynMb $ \dyn -> dynText dyn
+        elDynAttr "span" (pure mempty) $ pure unit
+
+      liftEffect (innerHTML node) `shouldReturn`
+        """<span></span>foobar<span></span>"""
+
+      liftEffect $ updateDyn Nothing
+      liftEffect (innerHTML node) `shouldReturn`
+        """<span></span><span></span>"""
+
+      -- clean up
+      liftEffect unsub
+
+    it "does not rerender contents when not necessary" $ withLeakCheck $ do
+      Tuple dynMb updateDyn  <- liftEffect $ newDynamic $ Nothing
+      count <- liftEffect $ newRef 0
+
+      T3 node _ unsub <- runBuilderInDiv' $ do
+        elDynAttr "span" (pure mempty) $ pure unit
+        whenJustD dynMb $ \dyn -> do
+          liftEffect $ modifyRef count (_ + 1)
+          dynText dyn
+        elDynAttr "span" (pure mempty) $ pure unit
+
+      liftEffect $ updateDyn $ Just "foo"
+      liftEffect $ updateDyn $ Just "bar"
+      liftEffect $ updateDyn $ Just "foo"
+      liftEffect $ updateDyn Nothing
+      liftEffect $ updateDyn $ Just "baz"
+      liftEffect $ updateDyn $ Just "bar"
+      liftEffect $ updateDyn $ Just "baz"
+      liftEffect (innerHTML node) `shouldReturn`
+        """<span></span>baz<span></span>"""
+
+      count `shouldHaveValue` 2
+      -- clean up
+      liftEffect unsub
+
 
   describe "domEventWithSample" $ do
     it "dispatches DOM events and handles unsubscribe" $ withLeakCheck $ do


### PR DESCRIPTION
New functions:

* `Specular.Callback`
  * `contramapCallbackDyn_`
* `Specular.Dom.Element`
  *  `dynText`
  *  `attr`
  *  `attrWhen`
  *  `attrUnless`
  *  `attrWhenD`
  *  `attrUnlessD`
  *  `attrsD`
  *  `attrsWhen`
  *  `attrsUnless`
  *  `attrsWhenD`
  *  `attrsUnlessD`
  *  `classWhen`
  *  `classUnless`
* `Specular.Dom.Widget`
  * `emptyWidget` – cherry-picked to #51 too
* `Specular.FRP.Base`
  * `filterJustEvent`
  * `uniqDyn`
* `Specular.FRP.Replacable`
  * `withDynamic_`
  * `whenJustD`
  * `whenD`
  * `unlessD`