### PR TITLE
foldDynM

### DIFF
--- a/src/Specular/FRP/Base.purs
+++ b/src/Specular/FRP/Base.purs
@@ -503,6 +503,8 @@ else instance monadFoldEffectCleanup :: (MonadCleanup m, MonadEffect m) => Monad
           Nothing ->
             pure oldValue
 
+    -- Since foldDyn can be called during a frame, 
+    -- make sure to pull at least once to make sure we get the first event, if any.
     _ <- pull updateOrReadValue
 
     unsub <- liftEffect $ event.subscribe $ void $ framePull $ updateOrReadValue


### PR DESCRIPTION
Related to: https://github.com/restaumatic/purescript-specular/issues/54

Here's a pull request with the changes I've made thus far that allow `foldDyn` to be called inside a frame update, added `foldDynM` which can create new dynamics when events are received.

***WORK IN PROGRESS*** This pull request, at the moment, is mostly meant as a way to comment on the proposed changes more easily, and signals an intent to eventually merge them in. The code is in a somewhat rough state and might need a bit of refactoring and/or reworking.

Done so far:
- Refactored the `foldDyn` into a monad `MonadFold`
- Implemented `foldDynM` which can be called in any `MonadFRP` (might be possible to call inside `MonadFold` as well with some modifications)
- Used `foldDynM` in an application (https://github.com/werner291/purechat/blob/f187423b67be44f1fb786ba97cfda9226332187a/src/API/ServerFeed.purs#L214) and confirmed it at least seems to work as intended.

Points to do:
- Assess whether the refactoring of `foldDyn` into a monad is acceptable so far. Also, notice that `foldDyn` now pulls the `updateOrReadValue` to make sure the current event is read, is that a valid thing to do in that situation?
- Look at other `(f/h)old*` functions and see how those can be made consistent witht he new changes.
- A general review of any changes made.