### PR TITLE
Fix height computation when subscribing to a dead bind

### DIFF
--- a/src/Specular/Internal/Incremental.purs
+++ b/src/Specular/Internal/Incremental.purs
@@ -141,10 +141,13 @@ connect = mkEffectFn1 \node -> do
   runEffectFn2 Array.iterate dependencies $ mkEffectFn1 \dependency -> do
     runEffectFn2 addDependent dependency (toSomeNode node)
     dependencyHeight <- runEffectFn1 Node.get_height dependency
+    adjustedHeight <- runEffectFn1 Node.get_adjustedHeight node
     ourHeight <- runEffectFn1 Node.get_height node
-    if dependencyHeight + 1 > ourHeight then do
-      runEffectFn2 Node.set_height node (dependencyHeight + 1)
-      runEffectFn2 Node.set_adjustedHeight node (dependencyHeight + 1)
+    let desiredHeight = max (dependencyHeight + 1) adjustedHeight
+    -- trace $ "connect " <> show (Node.name node) <> " -> " <> show (Node.name dependency) <> " dependencyHeight=" <> show dependencyHeight <> " ourHeight=" <> show ourHeight
+    if desiredHeight > ourHeight then do
+      runEffectFn2 Node.set_height node desiredHeight
+      runEffectFn2 Node.set_adjustedHeight node desiredHeight
     else
       pure unit
 

--- a/test/node/DynamicSpec.purs
+++ b/test/node/DynamicSpec.purs
@@ -11,7 +11,7 @@ import Effect.Ref (new)
 import Specular.FRP (Dynamic, foldDyn, foldDynMaybe, holdDyn, holdUniqDynBy, newEvent, readDynamic, subscribeDyn_, subscribeEvent_)
 import Specular.FRP.Base (changed, latestJust, newDynamic, subscribeDyn, uniqDynPure)
 import Specular.Ref as Ref
-import Test.Spec (Spec, describe, it, pending')
+import Test.Spec (Spec, describe, it)
 import Test.Utils (append, clear, liftEffect, shouldHaveValue, shouldReturn, withLeakCheck, withLeakCheck')
 
 -- | import Debug (traceM)
@@ -329,7 +329,7 @@ spec = describe "Dynamic" $ do
       -- clean up
       liftEffect unsub3
 
-    pending' "weird glitch test" $ withLeakCheck do
+    it "weird glitch test" $ withLeakCheck do
       -- Example minimized from a real-world bug.
       log <- liftEffect $ new []
       root <- Ref.new "1"


### PR DESCRIPTION
A bind node's height can change during `compute`. This was not taken into account previously, and an invalid height was used to
inform the height of a node subscribed to the bind. This of course violated the height invariant (that a node's height should be greater than all its dependencies), and caused errors in propagation.
